### PR TITLE
Port §12.13 legal-domain (enums/patterns/temporal API) to TypeScript (PORT-130/131/132/133)

### DIFF
--- a/src/services/legal-domain-knowledge.ts
+++ b/src/services/legal-domain-knowledge.ts
@@ -26,6 +26,12 @@ export enum LegalConceptType {
   AGENT            = 'agent',
   PENALTY          = 'penalty',
   EXEMPTION        = 'exemption',
+  // PORT-132: concept types from the Python reference (legal_domain_knowledge.py:36-49).
+  RIGHT            = 'right',
+  DUTY             = 'duty',
+  LIABILITY        = 'liability',
+  EXCEPTION        = 'exception',
+  DEFINITION       = 'definition',
 }
 
 export enum LegalDomainKind {
@@ -35,6 +41,16 @@ export enum LegalDomainKind {
   ADMINISTRATIVE = 'administrative',
   CIVIL          = 'civil',
   REGULATORY     = 'regulatory',
+  // PORT-130: domains from the Python reference (legal_domain_knowledge.py:21-33).
+  TORT                  = 'tort',
+  CORPORATE             = 'corporate',
+  EMPLOYMENT            = 'employment',
+  INTELLECTUAL_PROPERTY = 'intellectual_property',
+  REAL_ESTATE           = 'real_estate',
+  FAMILY                = 'family',
+  TAX                   = 'tax',
+  IMMIGRATION           = 'immigration',
+  ENVIRONMENTAL         = 'environmental',
 }
 
 export type DeonticOperatorKind = 'O' | 'P' | 'F';
@@ -117,6 +133,13 @@ export class LegalDomainKnowledge {
       makeLegalPattern(
         '\\b(?:is required|required to|needs to|has to)\\b',
         LegalConceptType.OBLIGATION, 'O', { confidence: 0.85, description: 'Requirement language' }),
+      // PORT-131: responsibility- and noun-based obligations (legal_domain_knowledge.py:114-129).
+      makeLegalPattern(
+        '\\b(?:responsible for|liable for|accountable for|in charge of)\\b',
+        LegalConceptType.OBLIGATION, 'O', { confidence: 0.80, description: 'Responsibility-based obligations', examples: ['Company responsible for damages', 'Tenant liable for repairs'] }),
+      makeLegalPattern(
+        '\\b(?:duty|obligation|responsibility|requirement)\\s+(?:to|of)\\b',
+        LegalConceptType.OBLIGATION, 'O', { confidence: 0.90, description: 'Noun-based obligation expressions', examples: ['duty to disclose', 'obligation of care'] }),
     ];
 
     this.permissionPatterns = [
@@ -126,15 +149,35 @@ export class LegalDomainKnowledge {
       makeLegalPattern(
         '\\b(?:can|could|is able to|is free to|at its discretion)\\b',
         LegalConceptType.PERMISSION, 'P', { confidence: 0.75, description: 'Capability/discretion language' }),
+      // PORT-131: entitlement-, rights- and option-based permissions (legal_domain_knowledge.py:143-166).
+      makeLegalPattern(
+        '\\b(?:entitled to|eligible for|qualified for|empowered to)\\b',
+        LegalConceptType.PERMISSION, 'P', { confidence: 0.90, description: 'Entitlement-based permissions', examples: ['Employee entitled to benefits', 'Shareholder eligible for dividends'] }),
+      makeLegalPattern(
+        '\\b(?:right|privilege|liberty|freedom|discretion)\\s+(?:to|of)\\b',
+        LegalConceptType.PERMISSION, 'P', { confidence: 0.85, description: 'Rights-based permissions', examples: ['right to privacy', 'freedom of speech'] }),
+      makeLegalPattern(
+        '\\b(?:option|choice|alternative)\\s+(?:to|of)\\b',
+        LegalConceptType.PERMISSION, 'P', { confidence: 0.75, description: 'Optional permissions', examples: ['option to renew', 'choice of law'] }),
     ];
 
     this.prohibitionPatterns = [
       makeLegalPattern(
-        '\\b(?:shall not|must not|is prohibited from|is forbidden to|cannot|may not)\\b',
+        '\\b(?:shall not|must not|is prohibited from|is forbidden to|cannot|may not|is barred from)\\b',
         LegalConceptType.PROHIBITION, 'F', { confidence: 0.95, description: 'Strong prohibition indicators' }),
       makeLegalPattern(
         '\\b(?:is not permitted|is not allowed|is not authorized|has no right to)\\b',
         LegalConceptType.PROHIBITION, 'F', { confidence: 0.90, description: 'Negated permission' }),
+      // PORT-131: adjective/verb, invalidity and violation-based prohibitions (legal_domain_knowledge.py:180-203).
+      makeLegalPattern(
+        '\\b(?:prohibited|forbidden|banned|barred|restricted|prevented)\\b',
+        LegalConceptType.PROHIBITION, 'F', { confidence: 0.90, description: 'Prohibition adjectives/verbs', examples: ['prohibited from entering', 'restricted from access'] }),
+      makeLegalPattern(
+        '\\b(?:unlawful|illegal|invalid|void|null and void|unenforceable)\\b',
+        LegalConceptType.PROHIBITION, 'F', { confidence: 0.85, description: 'Legal invalidity indicators', examples: ['unlawful to discriminate', 'void if violated'] }),
+      makeLegalPattern(
+        '\\b(?:violation|breach|infringement|non-compliance)\\s+(?:of|with)\\b',
+        LegalConceptType.PROHIBITION, 'F', { confidence: 0.80, description: 'Violation-based prohibitions', examples: ['breach of contract', 'infringement of rights'] }),
     ];
 
     this.agentPatterns = [
@@ -144,6 +187,13 @@ export class LegalDomainKnowledge {
       makeAgentPattern('\\b(?:the party|all parties|each party)\\b', 'person', 'Generic party'),
       makeAgentPattern('\\b(?:the court|the tribunal|the judge)\\b', 'government', 'Judicial authority'),
       makeAgentPattern('\\b(?:the officer|the official|the agent)\\b', 'role', 'Official role'),
+      // PORT-131: transactional/role agents from the Python reference (legal_domain_knowledge.py:215-267).
+      makeAgentPattern('\\b(?:buyer|purchaser|vendee|acquirer)\\b', 'person', 'Purchasing party in transactions', ['the buyer shall pay']),
+      makeAgentPattern('\\b(?:seller|vendor|grantor|transferor)\\b', 'person', 'Selling party in transactions', ['the seller warrants']),
+      makeAgentPattern('\\b(?:landlord|lessor|owner)\\b', 'person', 'Property owner/lessor', ['landlord shall maintain']),
+      makeAgentPattern('\\b(?:tenant|lessee|renter|occupant)\\b', 'person', 'Property tenant/lessee', ['tenant must pay']),
+      makeAgentPattern('\\b(?:employer|company|corporation|business|enterprise)\\b', 'organization', 'Business entities', ['employer shall provide']),
+      makeAgentPattern('\\b(?:employee|worker|staff|personnel)\\b', 'person', 'Workers/employees', ['employee must comply']),
     ];
 
     this.conditionPatterns = [

--- a/src/services/legal-symbolic-analyzer.ts
+++ b/src/services/legal-symbolic-analyzer.ts
@@ -210,6 +210,17 @@ export class LegalSymbolicAnalyzer {
   extractEntities(text: string): LegalEntity[] {
     return extractEntities(text);
   }
+
+  /**
+   * Extract temporal conditions (deadlines, periodicity, sequence) from text.
+   * PORT-133: expose the Python `extract_temporal_conditions`
+   * (integration/domain/legal_symbolic_analyzer.py) as a public method. The Python
+   * reference optionally delegates to SymbolicAI; the TS port stays regex-based by
+   * design (no ML runtime dependency) — mirrors analyze()'s 'heuristic_pattern_analysis'.
+   */
+  extractTemporalConditions(text: string): TemporalCondition[] {
+    return extractTemporalConditions(text);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/test/mcp-plus-plus/wasm-prover-legal-domain-port.test.ts
+++ b/test/mcp-plus-plus/wasm-prover-legal-domain-port.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Conformance: §12.13 Legal-domain TypeScript port (PORT-130/131/132/133).
+ *
+ * Verifies the TS legal-domain layer matches the Python reference
+ *   ipfs_datasets_py/logic/integration/domain/legal_domain_knowledge.py
+ *   ipfs_datasets_py/logic/integration/domain/legal_symbolic_analyzer.py
+ * for the enum coverage, deontic/agent pattern coverage, and the public
+ * temporal-extraction surface that doc 36 §12.13 catalogs as gaps.
+ *
+ * Each assertion cites the PORT-### task it closes.
+ */
+
+import {
+  LegalConceptType,
+  LegalDomainKind,
+  LegalDomainKnowledge,
+} from '../../src/services/legal-domain-knowledge';
+import { LegalSymbolicAnalyzer } from '../../src/services/legal-symbolic-analyzer';
+
+describe('§12.13 legal-domain port — enum parity with Python', () => {
+  it('PORT-130: LegalDomainKind covers all 12 Python LegalDomain values', () => {
+    // legal_domain_knowledge.py:21-33
+    const pythonDomains: Record<string, string> = {
+      CONTRACT: 'contract',
+      TORT: 'tort',
+      CRIMINAL: 'criminal',
+      CONSTITUTIONAL: 'constitutional',
+      CORPORATE: 'corporate',
+      EMPLOYMENT: 'employment',
+      INTELLECTUAL_PROPERTY: 'intellectual_property',
+      REAL_ESTATE: 'real_estate',
+      FAMILY: 'family',
+      TAX: 'tax',
+      IMMIGRATION: 'immigration',
+      ENVIRONMENTAL: 'environmental',
+    };
+    for (const [name, value] of Object.entries(pythonDomains)) {
+      expect((LegalDomainKind as Record<string, string>)[name]).toBe(value);
+    }
+  });
+
+  it('PORT-132: LegalConceptType covers all 10 Python LegalConceptType values', () => {
+    // legal_domain_knowledge.py:36-49
+    const pythonConcepts: Record<string, string> = {
+      OBLIGATION: 'obligation',
+      PERMISSION: 'permission',
+      PROHIBITION: 'prohibition',
+      RIGHT: 'right',
+      DUTY: 'duty',
+      LIABILITY: 'liability',
+      PENALTY: 'penalty',
+      CONDITION: 'condition',
+      EXCEPTION: 'exception',
+      DEFINITION: 'definition',
+    };
+    for (const [name, value] of Object.entries(pythonConcepts)) {
+      expect((LegalConceptType as Record<string, string>)[name]).toBe(value);
+    }
+  });
+});
+
+describe('§12.13 legal-domain port — pattern coverage (PORT-131)', () => {
+  const kb = new LegalDomainKnowledge();
+
+  const conceptOf = (text: string): Set<LegalConceptType> =>
+    new Set(kb.extractConcepts(text).map(c => c.conceptType));
+
+  it('detects responsibility- and noun-based obligations', () => {
+    // legal_domain_knowledge.py:114-129
+    expect(conceptOf('The company is responsible for damages')).toContain(LegalConceptType.OBLIGATION);
+    expect(conceptOf('the seller has a duty to disclose defects')).toContain(LegalConceptType.OBLIGATION);
+  });
+
+  it('detects entitlement-, rights- and option-based permissions', () => {
+    // legal_domain_knowledge.py:143-166
+    expect(conceptOf('Each employee is entitled to benefits')).toContain(LegalConceptType.PERMISSION);
+    expect(conceptOf('the tenant has a right to privacy')).toContain(LegalConceptType.PERMISSION);
+    expect(conceptOf('the lessee has an option to renew the lease')).toContain(LegalConceptType.PERMISSION);
+  });
+
+  it('detects adjective/verb, invalidity and violation prohibitions', () => {
+    // legal_domain_knowledge.py:169-204
+    expect(conceptOf('The contractor is barred from subcontracting')).toContain(LegalConceptType.PROHIBITION);
+    expect(conceptOf('employees are prohibited from disclosing secrets')).toContain(LegalConceptType.PROHIBITION);
+    expect(conceptOf('it is unlawful to discriminate')).toContain(LegalConceptType.PROHIBITION);
+    expect(conceptOf('any breach of contract voids the agreement')).toContain(LegalConceptType.PROHIBITION);
+  });
+
+  it('identifies transactional/role agents (PORT-131)', () => {
+    // legal_domain_knowledge.py:206-268
+    const agentsIn = (text: string) => new Set(kb.identifyAgents(text).map(a => a.agentType));
+    expect(agentsIn('the buyer shall pay the purchase price')).toContain('person');
+    expect(agentsIn('the seller warrants clear title')).toContain('person');
+    expect(agentsIn('the landlord shall maintain the premises')).toContain('person');
+    expect(agentsIn('the tenant must pay rent')).toContain('person');
+    expect(agentsIn('the employer shall provide insurance')).toContain('organization');
+    expect(agentsIn('every employee must comply with policy')).toContain('person');
+  });
+});
+
+describe('§12.13 legal-domain port — analyzer temporal surface (PORT-133)', () => {
+  const analyzer = new LegalSymbolicAnalyzer();
+
+  it('exposes a public extractTemporalConditions method', () => {
+    expect(typeof analyzer.extractTemporalConditions).toBe('function');
+  });
+
+  it('classifies deadline / periodicity / sequence temporal conditions', () => {
+    const deadline = analyzer.extractTemporalConditions('Payment is due within 30 days of delivery');
+    expect(deadline.some(c => c.conditionType === 'deadline')).toBe(true);
+
+    const periodic = analyzer.extractTemporalConditions('The report shall be filed annually');
+    expect(periodic.some(c => c.conditionType === 'periodicity')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Executes the **§12.13 Legal domain** slice of the doc-36 §12 TypeScript-port backlog — a faithful port of the Python legal-domain reference so the SwissKnife TS legal layer matches `ipfs_datasets_py` for the deontic policy use case.

Source of truth:
- `ipfs_datasets_py/logic/integration/domain/legal_domain_knowledge.py`
- `ipfs_datasets_py/logic/integration/domain/legal_symbolic_analyzer.py`

## Changes (closes 4 PORT tasks)

- **PORT-130** — `LegalDomainKind` gains the 9 missing Python `LegalDomain` values (`tort`, `corporate`, `employment`, `intellectual_property`, `real_estate`, `family`, `tax`, `immigration`, `environmental`). Now a superset of the 12 Python domains (keeps the TS-only `administrative`/`civil`/`regulatory`).
- **PORT-132** — `LegalConceptType` gains `right`/`duty`/`liability`/`exception`/`definition` → full 10-value parity with the Python enum.
- **PORT-131** — deontic pattern coverage brought up to the Python reference:
  - obligation: responsibility (`responsible for`, `liable for`) + noun forms (`duty/obligation/... to`)
  - permission: entitlement (`entitled/eligible`), rights (`right/privilege`), option (`option/choice`)
  - prohibition: adjective-verb (`prohibited/forbidden`), invalidity (`unlawful/illegal/void`), violation (`violation/breach`), `is barred from`
  - agents: `buyer`/`seller`/`landlord`/`tenant`/`employer`/`employee` transactional roles
- **PORT-133** — expose `LegalSymbolicAnalyzer.extractTemporalConditions()` as a public method (the temporal extractor already existed module-internally). Documents the intentional regex-over-SymbolicAI divergence (TS port stays ML-dependency-free by design).

## Tests

Adds `test/mcp-plus-plus/wasm-prover-legal-domain-port.test.ts` — 8 conformance tests (enum parity, deontic/agent pattern coverage, public temporal surface), all green. Per the §12 definition of done (a conformance test per PORT task).

```
npx jest test/mcp-plus-plus/wasm-prover-legal-domain-port.test.ts --config=config/jest/jest.config.cjs
# 8 passed
```

## Notes

- **Additive & non-colliding**: only enum members + pattern-array entries + one public wrapper method are added; no existing signatures change. Verified no external consumers of these enums break. The legal files are cold (untouched since ~Sprint 32) and were not modified by the concurrent WASM-prover sprint line — this branch merges cleanly into current `main` (`d94f464`).
- Type-checks clean under the project's ES2022 target.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>