### PR TITLE
Port formula dependency-graph analysis + DOT export to TypeScript (PORT-084)

### DIFF
--- a/src/services/formula-dependency-graph.ts
+++ b/src/services/formula-dependency-graph.ts
@@ -226,6 +226,240 @@ export class FormulaDependencyGraph {
   }
 
   // ---------------------------------------------------------------------------
+  // Transitive dependents / path analysis (Python-faithful) — PORT-084
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Transitive dependents of `id` (everything that (in)directly depends on it).
+   * Mirror of {@link getTransitiveDeps} in the reverse (`_radj`) direction.
+   *
+   * Python ref: `FormulaDependencyGraph.get_all_dependents()`.
+   */
+  getAllDependents(id: string): Set<string> {
+    const visited = new Set<string>();
+    const queue = [id];
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      for (const dep of this._radj.get(cur) ?? []) {
+        if (!visited.has(dep)) { visited.add(dep); queue.push(dep); }
+      }
+    }
+    visited.delete(id);
+    return visited;
+  }
+
+  /**
+   * Shortest proof path from `startId` (typically an axiom) to `endId`
+   * (typically a theorem), following the dependents direction — i.e. "what is
+   * derived from start until we reach end". BFS ⇒ shortest by hop count.
+   * Returns node IDs, or null if unreachable.
+   *
+   * Python ref: `FormulaDependencyGraph.find_critical_path()`.
+   */
+  findCriticalPath(startId: string, endId: string): string[] | null {
+    if (!this._nodes.has(startId) || !this._nodes.has(endId)) return null;
+    if (startId === endId) return [startId];
+
+    const visited = new Set<string>([startId]);
+    const queue: Array<{ id: string; path: string[] }> = [{ id: startId, path: [startId] }];
+    while (queue.length > 0) {
+      const { id, path } = queue.shift()!;
+      if (id === endId) return path;
+      for (const dependent of this._radj.get(id) ?? []) {
+        if (!visited.has(dependent)) {
+          visited.add(dependent);
+          queue.push({ id: dependent, path: [...path, dependent] });
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * All (acyclic) paths from `startId` to `endId` in the dependents direction,
+   * each path a list of node IDs. `maxLength` optionally bounds path length.
+   *
+   * Python ref: `FormulaDependencyGraph.find_all_paths()`.
+   */
+  findAllPaths(startId: string, endId: string, maxLength?: number): string[][] {
+    if (!this._nodes.has(startId) || !this._nodes.has(endId)) return [];
+    const allPaths: string[][] = [];
+
+    const dfs = (current: string, path: string[], visited: Set<string>): void => {
+      if (maxLength !== undefined && path.length > maxLength) return;
+      if (current === endId) { allPaths.push([...path]); return; }
+      for (const dependent of this._radj.get(current) ?? []) {
+        if (!visited.has(dependent)) {
+          visited.add(dependent);
+          path.push(dependent);
+          dfs(dependent, path, visited);
+          path.pop();
+          visited.delete(dependent);
+        }
+      }
+    };
+
+    dfs(startId, [startId], new Set<string>([startId]));
+    return allPaths;
+  }
+
+  /**
+   * Axioms that are not used in any derivation (have no dependents).
+   *
+   * Python ref: `FormulaDependencyGraph.find_unused_axioms()`.
+   */
+  findUnusedAxioms(): string[] {
+    const unused: string[] = [];
+    for (const [id, node] of this._nodes) {
+      if (node.formulaType === 'axiom' && (this._radj.get(id) ?? []).length === 0) {
+        unused.push(id);
+      }
+    }
+    return unused;
+  }
+
+  /**
+   * Pairs `[a, b]` where `a` (transitively) depends on `b` — i.e. `a` may be
+   * redundant given `b`. Each unordered pair is reported at most once.
+   *
+   * Python ref: `FormulaDependencyGraph.find_redundant_formulas()`.
+   */
+  findRedundantFormulas(): Array<[string, string]> {
+    const redundant: Array<[string, string]> = [];
+    const ids = [...this._nodes.keys()];
+    for (let i = 0; i < ids.length; i++) {
+      const f1 = ids[i];
+      const deps1 = this.getTransitiveDeps(f1);
+      for (let j = i + 1; j < ids.length; j++) {
+        const f2 = ids[j];
+        if (deps1.has(f2)) redundant.push([f1, f2]);
+        else if (this.getTransitiveDeps(f2).has(f1)) redundant.push([f2, f1]);
+      }
+    }
+    return redundant;
+  }
+
+  /**
+   * Summary statistics: node/edge counts, per-type breakdowns, cycle presence,
+   * and axiom/theorem counts.
+   *
+   * Python ref: `FormulaDependencyGraph.get_statistics()`.
+   */
+  getStatistics(): {
+    num_nodes: number;
+    num_edges: number;
+    node_types: Record<string, number>;
+    edge_types: Record<string, number>;
+    has_cycles: boolean;
+    num_axioms: number;
+    num_theorems: number;
+  } {
+    const nodeTypes: Record<string, number> = {};
+    for (const node of this._nodes.values()) {
+      nodeTypes[node.formulaType] = (nodeTypes[node.formulaType] ?? 0) + 1;
+    }
+    const edgeTypes: Record<string, number> = {};
+    for (const edge of this._edges) {
+      edgeTypes[edge.depType] = (edgeTypes[edge.depType] ?? 0) + 1;
+    }
+    return {
+      num_nodes: this._nodes.size,
+      num_edges: this._edges.length,
+      node_types: nodeTypes,
+      edge_types: edgeTypes,
+      has_cycles: this.detectCycles().length > 0,
+      num_axioms: nodeTypes['axiom'] ?? 0,
+      num_theorems: nodeTypes['theorem'] ?? 0,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GraphViz DOT export
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Render the graph as a GraphViz DOT string (edges `source -> target`,
+   * i.e. dependency direction). Nodes are coloured by formula type; an optional
+   * `highlightPath` (node IDs) is drawn in red; nodes may be clustered by type.
+   *
+   * Returns the DOT text (the caller decides where to write it — this library
+   * stays filesystem-free, unlike the Python `export_dot` which writes a file).
+   *
+   * Python ref: `FormulaDependencyGraph.export_dot()`.
+   */
+  exportDot(options: {
+    highlightPath?: readonly string[];
+    includeLabels?: boolean;
+    clusterByType?: boolean;
+  } = {}): string {
+    const { highlightPath, includeLabels = true, clusterByType = true } = options;
+    const highlight = new Set(highlightPath ?? []);
+
+    const nodeStyles: Record<string, string> = {
+      axiom:      'fillcolor=lightblue, style="rounded,filled"',
+      theorem:    'fillcolor=lightgreen, style="rounded,filled"',
+      lemma:      'fillcolor=lightcyan, style="rounded,filled"',
+      goal:       'fillcolor=gold, style="rounded,filled"',
+      hypothesis: 'fillcolor=lightgray, style="rounded,filled"',
+      conclusion: 'fillcolor=lightyellow, style="rounded,filled"',
+      definition: 'fillcolor=lavender, style="rounded,filled"',
+    };
+    const styleFor = (t: string): string => nodeStyles[t] ?? 'style="rounded,filled", fillcolor=white';
+
+    // Deterministic DOT-safe id per node (insertion order).
+    const dotId = new Map<string, string>();
+    let i = 0;
+    for (const id of this._nodes.keys()) dotId.set(id, `n${i++}`);
+    const esc = (s: string): string => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const labelOf = (id: string, node: DependencyNode): string => {
+      const name = node.metadata['name'];
+      return typeof name === 'string' && name ? name : (node.formula || id);
+    };
+
+    const lines: string[] = ['digraph DependencyGraph {', '  rankdir=TB;', '  node [shape=box, style=rounded];', ''];
+
+    const emitNode = (id: string, node: DependencyNode, indent: string): void => {
+      let style = styleFor(node.formulaType);
+      if (highlight.has(id)) style += ', penwidth=3, color=red';
+      lines.push(`${indent}${dotId.get(id)} [label="${esc(labelOf(id, node))}", ${style}];`);
+    };
+
+    if (clusterByType) {
+      const groups = new Map<string, Array<[string, DependencyNode]>>();
+      for (const [id, node] of this._nodes) {
+        if (!groups.has(node.formulaType)) groups.set(node.formulaType, []);
+        groups.get(node.formulaType)!.push([id, node]);
+      }
+      for (const [type, group] of groups) {
+        lines.push(`  subgraph cluster_${type} {`);
+        lines.push(`    label="${type.charAt(0).toUpperCase()}${type.slice(1)}";`);
+        lines.push('    style=dashed;');
+        lines.push('    color=gray;');
+        for (const [id, node] of group) emitNode(id, node, '    ');
+        lines.push('  }');
+        lines.push('');
+      }
+    } else {
+      for (const [id, node] of this._nodes) emitNode(id, node, '  ');
+      lines.push('');
+    }
+
+    for (const edge of this._edges) {
+      const src = dotId.get(edge.sourceId);
+      const tgt = dotId.get(edge.targetId);
+      if (!src || !tgt) continue;
+      const attrs: string[] = [];
+      const rule = edge.metadata['rule_name'] ?? edge.metadata['ruleName'];
+      if (includeLabels && typeof rule === 'string' && rule) attrs.push(`label="${esc(rule)}"`);
+      if (highlight.has(edge.sourceId) && highlight.has(edge.targetId)) attrs.push('color=red, penwidth=2');
+      lines.push(attrs.length > 0 ? `  ${src} -> ${tgt} [${attrs.join(', ')}];` : `  ${src} -> ${tgt};`);
+    }
+
+    lines.push('}');
+    return lines.join('\n');
+  }
+
+  // ---------------------------------------------------------------------------
   // Serialisation
   // ---------------------------------------------------------------------------
 

--- a/test/mcp-plus-plus/wasm-prover-dep-graph-port.test.ts
+++ b/test/mcp-plus-plus/wasm-prover-dep-graph-port.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Conformance: §12.8 PORT-084 — Formula dependency-graph analysis + DOT export.
+ *
+ * Verifies the TS `FormulaDependencyGraph` matches the Python reference
+ *   ipfs_datasets_py/logic/TDFOL/formula_dependency_graph.py
+ * for the previously-missing surface: transitive dependents, critical/all
+ * shortest paths, unused-axiom & redundancy detection, statistics, and GraphViz
+ * DOT export.
+ */
+
+import {
+  FormulaDependencyGraph,
+  type DependencyNode,
+  type DependencyEdge,
+} from '../../src/services/formula-dependency-graph';
+
+function node(id: string, formulaType: DependencyNode['formulaType'], name?: string): DependencyNode {
+  return { id, formula: `${id}_formula`, formulaType, metadata: name ? { name } : {} };
+}
+function edge(sourceId: string, targetId: string, rule?: string): DependencyEdge {
+  return { sourceId, targetId, depType: 'DERIVES', weight: 1, metadata: rule ? { rule_name: rule } : {} };
+}
+
+/** A (axiom) <- L (lemma) <- C (theorem); B is an unused axiom. */
+function buildGraph(): FormulaDependencyGraph {
+  const g = new FormulaDependencyGraph();
+  g.addNode(node('A', 'axiom', 'AxiomA'));
+  g.addNode(node('B', 'axiom', 'AxiomB'));
+  g.addNode(node('L', 'lemma', 'LemmaL'));
+  g.addNode(node('C', 'theorem', 'TheoremC'));
+  g.addEdge(edge('L', 'A', 'ModusPonens')); // L depends on A
+  g.addEdge(edge('C', 'L', 'Simplification')); // C depends on L
+  return g;
+}
+
+describe('PORT-084 dependency-graph analysis', () => {
+  it('getAllDependents returns transitive dependents', () => {
+    const g = buildGraph();
+    expect(g.getAllDependents('A')).toEqual(new Set(['L', 'C']));
+    expect(g.getAllDependents('C')).toEqual(new Set()); // nothing depends on the theorem
+  });
+
+  it('findCriticalPath returns the shortest axiom→theorem path', () => {
+    const g = buildGraph();
+    expect(g.findCriticalPath('A', 'C')).toEqual(['A', 'L', 'C']);
+    expect(g.findCriticalPath('A', 'A')).toEqual(['A']);
+    expect(g.findCriticalPath('A', 'ZZZ')).toBeNull();
+  });
+
+  it('findAllPaths enumerates every dependents-direction path', () => {
+    const g = buildGraph();
+    expect(g.findAllPaths('A', 'C')).toEqual([['A', 'L', 'C']]);
+    expect(g.findAllPaths('A', 'C', 1)).toEqual([]); // bounded below the required length
+  });
+
+  it('findUnusedAxioms returns only axioms with no dependents', () => {
+    const g = buildGraph();
+    expect(g.findUnusedAxioms()).toEqual(['B']); // A is used by L
+  });
+
+  it('findRedundantFormulas returns (dependent, dependency) pairs', () => {
+    const g = buildGraph();
+    const pairs = g.findRedundantFormulas().map(p => p.join('<-'));
+    expect(pairs).toContain('L<-A');
+    expect(pairs).toContain('C<-A');
+    expect(pairs).toContain('C<-L');
+    expect(pairs).toHaveLength(3);
+  });
+
+  it('getStatistics summarises the graph', () => {
+    const stats = buildGraph().getStatistics();
+    expect(stats.num_nodes).toBe(4);
+    expect(stats.num_edges).toBe(2);
+    expect(stats.num_axioms).toBe(2);
+    expect(stats.num_theorems).toBe(1);
+    expect(stats.has_cycles).toBe(false);
+    expect(stats.node_types).toEqual({ axiom: 2, lemma: 1, theorem: 1 });
+    expect(stats.edge_types).toEqual({ DERIVES: 2 });
+  });
+
+  it('getStatistics reports cycles when present', () => {
+    const g = new FormulaDependencyGraph();
+    g.addNode(node('X', 'theorem'));
+    g.addNode(node('Y', 'theorem'));
+    g.addEdge(edge('X', 'Y'));
+    g.addEdge(edge('Y', 'X'));
+    expect(g.getStatistics().has_cycles).toBe(true);
+  });
+});
+
+describe('PORT-084 GraphViz DOT export', () => {
+  it('emits a valid clustered digraph with typed nodes and directed edges', () => {
+    const dot = buildGraph().exportDot();
+    expect(dot.startsWith('digraph DependencyGraph {')).toBe(true);
+    expect(dot).toContain('subgraph cluster_axiom');
+    expect(dot).toContain('subgraph cluster_theorem');
+    expect(dot).toContain('fillcolor=lightblue'); // axiom style
+    expect(dot).toContain('label="AxiomA"'); // uses metadata.name
+    expect(dot).toContain('label="ModusPonens"'); // edge rule label
+    expect(dot).toMatch(/n\d+ -> n\d+/); // directed edges
+    expect(dot.trimEnd().endsWith('}')).toBe(true);
+  });
+
+  it('highlights the requested path in red', () => {
+    const dot = buildGraph().exportDot({ highlightPath: ['A', 'L', 'C'] });
+    expect(dot).toContain('penwidth=3, color=red'); // highlighted node
+    expect(dot).toContain('color=red, penwidth=2'); // highlighted edge
+  });
+
+  it('honours includeLabels=false and clusterByType=false', () => {
+    const dot = buildGraph().exportDot({ includeLabels: false, clusterByType: false });
+    expect(dot).not.toContain('subgraph cluster_');
+    expect(dot).not.toContain('label="ModusPonens"');
+  });
+});


### PR DESCRIPTION
## Summary

Executes **§12.8 PORT-084** of the doc-36 §12 TypeScript-port backlog — a faithful port of the analysis + export surface from the Python `FormulaDependencyGraph` that the TS class was missing.

Source of truth: `ipfs_datasets_py/logic/TDFOL/formula_dependency_graph.py`.

## New methods on `FormulaDependencyGraph`

- `getAllDependents(id)` — transitive dependents (reverse of the existing `getTransitiveDeps`).
- `findCriticalPath(start, end)` — shortest axiom→theorem path (BFS in the dependents direction), the Python `find_critical_path`.
- `findAllPaths(start, end, maxLength?)` — all acyclic paths (`find_all_paths`).
- `findUnusedAxioms()` — axioms with no dependents (`find_unused_axioms`).
- `findRedundantFormulas()` — `(dependent, dependency)` pairs (`find_redundant_formulas`).
- `getStatistics()` — node/edge counts, per-type breakdown, cycle presence (`get_statistics`).
- `exportDot({ highlightPath, includeLabels, clusterByType })` — GraphViz DOT export (`export_dot`). Returns the DOT **string** (the library stays filesystem-free; the caller writes it), with type-coloured nodes, optional path highlighting in red, and clustering by formula type.

## Tests

Adds `test/mcp-plus-plus/wasm-prover-dep-graph-port.test.ts` — 10 conformance tests (transitive dependents, critical/all paths, unused-axiom & redundancy detection, statistics incl. cycles, DOT structure/highlight/options), all green. Per the §12 definition of done.

```
npx jest test/mcp-plus-plus/wasm-prover-dep-graph-port.test.ts --config=config/jest/jest.config.cjs
# 10 passed
```

## Notes

- **Additive & non-colliding**: only new methods are added; no existing signature changes. The existing Sprint-23 consumer test stays green (24/24). `formula-dependency-graph.ts` is cold (last touched Sprint 23, ~26h before this) and untouched by the concurrent WASM-prover sprint line — merges cleanly into current `main` (`d94f464`).
- Type-checks clean under the project's ES2022 target.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>