### PR TITLE
chore: resync mcp-ipfs-kit-tools-manifest from kit registry

### DIFF
--- a/build-tools/configs/playwright.ui-ux-ir.config.ts
+++ b/build-tools/configs/playwright.ui-ux-ir.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * UIR-081: lightweight config for hardware-free pilot markers.
+ * Prefer unit/integration suites for mediation; this gate is intentionally thin.
+ */
+export default defineConfig({
+  testDir: '../../test/e2e',
+  testMatch: '**/ui-ux-ir-pilots.spec.ts',
+  timeout: 30_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  use: {
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'chromium-markers',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/src/services/glasses/ui-ux-ir-glasses-adapter.ts
+++ b/src/services/glasses/ui-ux-ir-glasses-adapter.ts
@@ -1,0 +1,1107 @@
+/**
+ * UIIRGlassesAdapter@1 — Meta-glasses and spatial projection adapter.
+ *
+ * Maps UI/UX IR semantic items onto bounded HUD cards, actions, status,
+ * privacy indicators, audio summaries, and mobile companion fallbacks while
+ * respecting current Meta DAT versus Web App capability paths.
+ *
+ * Constraints (UIR-001 Meta capability matrix / UIR-043):
+ * - Web Apps expose Neural Band/captouch as Arrow/Enter-style intents only.
+ * - DAT is a distinct capability path; never collapse DAT and Web App.
+ * - Continuous cursor, free-form touch, continuous text input, and raw EMG
+ *   are never assumed or fabricated.
+ * - Mandatory semantics that do not fit fall back to mobile/audio or fail
+ *   with an explicit loss receipt. Privacy indicators and confirmations
+ *   always survive or are marked unsatisfiable.
+ */
+
+export const UIIR_GLASSES_ADAPTER_INTERFACE = 'UIIRGlassesAdapter@1' as const;
+export const UIIR_GLASSES_PROJECTION_INTERFACE = 'UIIRGlassesProjection@1' as const;
+export const UIIR_GLASSES_PROJECTION_SCHEMA_VERSION = 'ui-glasses-projection/v1' as const;
+
+export const ARROW_ENTER_TOKENS = [
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'Enter',
+] as const;
+
+export type ArrowEnterToken = (typeof ARROW_ENTER_TOKENS)[number];
+
+export const ARROW_ENTER_INTENT_MAP: Readonly<Record<string, string>> = Object.freeze({
+  ArrowUp: 'navigate_up',
+  ArrowDown: 'navigate_down',
+  ArrowLeft: 'navigate_left',
+  ArrowRight: 'navigate_right',
+  Enter: 'activate',
+  arrowup: 'navigate_up',
+  arrowdown: 'navigate_down',
+  arrowleft: 'navigate_left',
+  arrowright: 'navigate_right',
+  enter: 'activate',
+  up: 'navigate_up',
+  down: 'navigate_down',
+  left: 'navigate_left',
+  right: 'navigate_right',
+  select: 'activate',
+});
+
+export const UNSUPPORTED_GLASSES_ASSUMPTIONS = [
+  'continuous_cursor',
+  'freeform_touch',
+  'continuous_text_input',
+  'raw_emg',
+  'raw_neural_stream',
+  'full_touchscreen_pointer',
+] as const;
+
+export type UnsupportedGlassesAssumption =
+  (typeof UNSUPPORTED_GLASSES_ASSUMPTIONS)[number];
+
+export type GlassesCapabilityPath = 'dat' | 'web_app' | 'simulator';
+
+export type GlassesSurfaceKind =
+  | 'hud_card'
+  | 'action'
+  | 'status'
+  | 'confirmation'
+  | 'privacy_indicator'
+  | 'audio_summary'
+  | 'mobile_fallback'
+  | 'notification'
+  | 'unsatisfiable';
+
+export type GlassesInputSource =
+  | 'neural_band'
+  | 'captouch'
+  | 'dpad'
+  | 'speech'
+  | 'hand_gesture'
+  | 'gaze'
+  | 'head_pose'
+  | 'mobile_action';
+
+export type GlassesRenderPath =
+  | 'dat-native'
+  | 'display-webapp'
+  | 'simulator'
+  | 'mobile-card'
+  | 'audio-summary'
+  | 'notification';
+
+export type GlassesProjectionStatus =
+  | 'satisfied'
+  | 'degraded'
+  | 'fallback'
+  | 'unsatisfiable'
+  | 'bound_exceeded';
+
+export type GlassesDisposition =
+  | 'preserved'
+  | 'adapted'
+  | 'summarized'
+  | 'fallback'
+  | 'omitted'
+  | 'unsatisfiable';
+
+export type GlassesLossCategory =
+  | 'preserved'
+  | 'adapted'
+  | 'summarized'
+  | 'fallback'
+  | 'omitted'
+  | 'degraded'
+  | 'unsupported'
+  | 'unsatisfiable'
+  | 'budget_exceeded';
+
+export type GlassesMandatoryKind =
+  | 'action'
+  | 'consent'
+  | 'consequence'
+  | 'error'
+  | 'confirmation'
+  | 'feedback'
+  | 'accessibility'
+  | 'privacy';
+
+export interface GlassesBudgetLimits {
+  action_count: number;
+  text_chars: number;
+  update_hz: number;
+  field_of_view: number;
+  attention: number;
+  latency_ms: number;
+}
+
+export interface GlassesCapabilityProfile {
+  profile_id: string;
+  capability_path: GlassesCapabilityPath;
+  family: 'glasses';
+  input_capability_ids: readonly string[];
+  output_capability_ids: readonly string[];
+  budgets: GlassesBudgetLimits;
+  render_path: GlassesRenderPath;
+  description: string;
+  /** Explicit denials — never claimed true for glasses projection. */
+  unsupported_assumptions: readonly UnsupportedGlassesAssumption[];
+  continuous_cursor: false;
+  freeform_touch: false;
+  continuous_text_input: false;
+  raw_emg: false;
+}
+
+export interface GlassesSemanticItem {
+  item_id: string;
+  semantic_kind: string;
+  mandatory?: boolean;
+  label?: string;
+  text?: string;
+  component_id?: string;
+  action_cost?: number;
+  text_chars?: number;
+  update_rate?: number;
+  field_of_view_share?: number;
+  attention_cost?: number;
+  priority?: number;
+  fallback_ref?: string;
+  required_capability_ids?: readonly string[];
+  fallback_capability_ids?: readonly string[];
+}
+
+export interface GlassesProjectionRequest {
+  document_id?: string;
+  projection_id?: string;
+  capability_path?: GlassesCapabilityPath;
+  items: readonly GlassesSemanticItem[];
+  title?: string;
+}
+
+export interface GlassesInputBinding {
+  binding_id: string;
+  source: GlassesInputSource;
+  capability_id: string;
+  capability_path: GlassesCapabilityPath;
+  admitted_tokens: readonly ArrowEnterToken[];
+  intent_map: Readonly<Record<ArrowEnterToken, string>>;
+  raw_emg_allowed: false;
+  continuous_cursor_allowed: false;
+  freeform_touch_allowed: false;
+  continuous_text_input_allowed: false;
+}
+
+export interface GlassesLossEntry {
+  loss_id: string;
+  semantic_id: string;
+  semantic_kind: string;
+  category: GlassesLossCategory;
+  reason: string;
+  mandatory: boolean;
+  fallback_ref?: string;
+  budget_kind?: string;
+  details?: readonly string[];
+}
+
+export interface GlassesPresentationNode {
+  node_id: string;
+  surface: GlassesSurfaceKind;
+  semantic_id: string;
+  semantic_kind: string;
+  disposition: GlassesDisposition;
+  mandatory: boolean;
+  order: number;
+  label: string;
+  text: string;
+  action_id: string;
+  focus_index: number | null;
+  fallback_ref: string;
+  component_id: string;
+}
+
+export interface GlassesBudgetReceipt {
+  action_count: number;
+  action_limit: number;
+  text_chars: number;
+  text_limit: number;
+  update_hz: number;
+  update_limit: number;
+  field_of_view_share: number;
+  field_of_view_limit: number;
+  exceeded: readonly string[];
+}
+
+export interface GlassesCapabilityReceipt {
+  capability_path: GlassesCapabilityPath;
+  profile_id: string;
+  render_path: GlassesRenderPath;
+  input_capability_ids: readonly string[];
+  output_capability_ids: readonly string[];
+  unsupported_assumptions: readonly UnsupportedGlassesAssumption[];
+  dat_webapp_collapsed: false;
+}
+
+export interface GlassesCompilerHandoff {
+  template: string;
+  render_path: GlassesRenderPath;
+  max_actions: number;
+  max_text_chars: number;
+  max_update_hz: number;
+  focus_order: readonly string[];
+  actions: readonly {
+    id: string;
+    method: string;
+    backend_action_id: string;
+    label: string;
+    focusable: boolean;
+  }[];
+  regions: readonly Record<string, unknown>[];
+  fallbacks: readonly Record<string, unknown>[];
+  input_kinds: readonly string[];
+}
+
+export interface UIIRGlassesProjection {
+  interface: typeof UIIR_GLASSES_PROJECTION_INTERFACE;
+  schema_version: typeof UIIR_GLASSES_PROJECTION_SCHEMA_VERSION;
+  projection_id: string;
+  document_id: string;
+  profile_id: string;
+  capability_path: GlassesCapabilityPath;
+  status: GlassesProjectionStatus;
+  nodes: readonly GlassesPresentationNode[];
+  input_bindings: readonly GlassesInputBinding[];
+  losses: readonly GlassesLossEntry[];
+  budget_receipt: GlassesBudgetReceipt;
+  capability_receipt: GlassesCapabilityReceipt;
+  compiler_handoff: GlassesCompilerHandoff;
+}
+
+export interface GlassesIntentNormalizationResult {
+  token: ArrowEnterToken | string;
+  intent: string;
+  source: GlassesInputSource;
+  capability_path: GlassesCapabilityPath;
+  raw_emg: false;
+  continuous_cursor: false;
+}
+
+export class UIIRGlassesAdapterError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code = 'UIIR_GLASSES_ADAPTER_ERROR') {
+    super(message);
+    this.name = 'UIIRGlassesAdapterError';
+    this.code = code;
+  }
+}
+
+const SURVIVAL_KINDS = new Set<string>([
+  'confirmation',
+  'privacy',
+  'consent',
+  'consequence',
+]);
+
+const MANDATORY_KINDS = new Set<string>([
+  'action',
+  'consent',
+  'consequence',
+  'error',
+  'confirmation',
+  'feedback',
+  'accessibility',
+  'privacy',
+]);
+
+const DEFAULT_BUDGETS: GlassesBudgetLimits = Object.freeze({
+  action_count: 4,
+  text_chars: 180,
+  update_hz: 10,
+  field_of_view: 30,
+  attention: 25,
+  latency_ms: 80,
+});
+
+const WEB_APP_PROFILE: GlassesCapabilityProfile = Object.freeze({
+  profile_id: 'profile:glasses:web_app',
+  capability_path: 'web_app',
+  family: 'glasses',
+  input_capability_ids: Object.freeze([
+    'dpad_captouch',
+    'neural_band_normalized',
+    'speech',
+  ]),
+  output_capability_ids: Object.freeze([
+    'spatial_display',
+    'audio',
+    'speech_output',
+    'mobile_companion',
+    'notification',
+    'fallback',
+  ]),
+  budgets: DEFAULT_BUDGETS,
+  render_path: 'display-webapp',
+  description:
+    'Meta Web App glasses path: Neural Band/captouch as Arrow/Enter intents; no camera/mic/raw-EMG claims',
+  unsupported_assumptions: UNSUPPORTED_GLASSES_ASSUMPTIONS,
+  continuous_cursor: false,
+  freeform_touch: false,
+  continuous_text_input: false,
+  raw_emg: false,
+});
+
+const DAT_PROFILE: GlassesCapabilityProfile = Object.freeze({
+  profile_id: 'profile:glasses:dat',
+  capability_path: 'dat',
+  family: 'glasses',
+  input_capability_ids: Object.freeze([
+    'dpad_captouch',
+    'neural_band_normalized',
+    'gaze',
+    'head_pose',
+    'speech',
+    'hand_gesture',
+  ]),
+  output_capability_ids: Object.freeze([
+    'spatial_display',
+    'audio',
+    'speech_output',
+    'haptic',
+    'mobile_companion',
+    'notification',
+    'fallback',
+  ]),
+  budgets: Object.freeze({
+    ...DEFAULT_BUDGETS,
+    attention: 30,
+  }),
+  render_path: 'dat-native',
+  description:
+    'Meta DAT glasses path: native spatial display with normalized embodied inputs; distinct from Web App',
+  unsupported_assumptions: UNSUPPORTED_GLASSES_ASSUMPTIONS,
+  continuous_cursor: false,
+  freeform_touch: false,
+  continuous_text_input: false,
+  raw_emg: false,
+});
+
+const SIMULATOR_PROFILE: GlassesCapabilityProfile = Object.freeze({
+  ...WEB_APP_PROFILE,
+  profile_id: 'profile:glasses:simulator',
+  capability_path: 'simulator',
+  render_path: 'simulator',
+  description: 'Hardware-free Meta glasses simulator projection path',
+});
+
+export function glassesCapabilityProfile(
+  path: GlassesCapabilityPath = 'web_app',
+): GlassesCapabilityProfile {
+  if (path === 'dat') return DAT_PROFILE;
+  if (path === 'simulator') return SIMULATOR_PROFILE;
+  if (path === 'web_app') return WEB_APP_PROFILE;
+  throw new UIIRGlassesAdapterError(
+    `Unknown glasses capability path: ${String(path)}`,
+    'UNKNOWN_CAPABILITY_PATH',
+  );
+}
+
+export function renderPathForCapabilityPath(
+  path: GlassesCapabilityPath,
+): GlassesRenderPath {
+  return glassesCapabilityProfile(path).render_path;
+}
+
+export function isSupportedArrowEnterToken(token: string): token is ArrowEnterToken {
+  if (typeof token !== 'string' || !token.trim()) return false;
+  const key = token.trim();
+  return key in ARROW_ENTER_INTENT_MAP || key.toLowerCase() in ARROW_ENTER_INTENT_MAP;
+}
+
+export function normalizeArrowEnterIntent(token: string): string {
+  if (typeof token !== 'string' || !token.trim()) {
+    throw new UIIRGlassesAdapterError(
+      'Arrow/Enter intent token must be a non-empty string',
+      'INVALID_INTENT_TOKEN',
+    );
+  }
+  const key = token.trim();
+  const intent =
+    ARROW_ENTER_INTENT_MAP[key] ?? ARROW_ENTER_INTENT_MAP[key.toLowerCase()];
+  if (!intent) {
+    throw new UIIRGlassesAdapterError(
+      `Unsupported glasses intent token ${JSON.stringify(token)}; expected Arrow/Enter-style normalized intents only (admitted: ${ARROW_ENTER_TOKENS.join(', ')})`,
+      'UNSUPPORTED_INTENT_TOKEN',
+    );
+  }
+  return intent;
+}
+
+export function defaultInputBindings(
+  capabilityPath: GlassesCapabilityPath,
+): GlassesInputBinding[] {
+  const intentMap = Object.fromEntries(
+    ARROW_ENTER_TOKENS.map(token => [token, ARROW_ENTER_INTENT_MAP[token]]),
+  ) as Record<ArrowEnterToken, string>;
+
+  const base = {
+    admitted_tokens: ARROW_ENTER_TOKENS,
+    intent_map: Object.freeze(intentMap),
+    capability_path: capabilityPath,
+    raw_emg_allowed: false as const,
+    continuous_cursor_allowed: false as const,
+    freeform_touch_allowed: false as const,
+    continuous_text_input_allowed: false as const,
+  };
+
+  return [
+    {
+      ...base,
+      binding_id: `binding:${capabilityPath}:neural_band`,
+      source: 'neural_band',
+      capability_id: 'neural_band_normalized',
+    },
+    {
+      ...base,
+      binding_id: `binding:${capabilityPath}:captouch`,
+      source: 'captouch',
+      capability_id: 'dpad_captouch',
+    },
+    {
+      ...base,
+      binding_id: `binding:${capabilityPath}:dpad`,
+      source: 'dpad',
+      capability_id: 'dpad_captouch',
+    },
+  ];
+}
+
+export function rejectFabricatedCapabilityClaims(
+  payload: Record<string, unknown>,
+): void {
+  if (payload == null || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new UIIRGlassesAdapterError(
+      'capability claim payload must be a mapping',
+      'INVALID_CAPABILITY_CLAIM',
+    );
+  }
+  const keys = Object.keys(payload).map(k => k.toLowerCase());
+  const values = Object.values(payload)
+    .filter((v): v is string => typeof v === 'string')
+    .map(v => v.toLowerCase());
+  const hits = new Set(
+    [...keys, ...values].filter(item =>
+      [
+        'raw_emg',
+        'emg_raw',
+        'continuous_cursor',
+        'freeform_touch',
+        'continuous_text_input',
+        'neural_band_raw',
+        'raw_neural_stream',
+      ].includes(item),
+    ),
+  );
+  // Only fail when a claim asserts these as available/true, not when listing denials.
+  const assertedTrue = [
+    'raw_emg',
+    'continuous_cursor',
+    'freeform_touch',
+    'continuous_text_input',
+    'raw_neural_stream',
+  ].filter(key => payload[key] === true);
+  if (assertedTrue.length > 0) {
+    throw new UIIRGlassesAdapterError(
+      `Fabricated glasses capability claims are forbidden: ${assertedTrue.join(', ')}`,
+      'FABRICATED_CAPABILITY',
+    );
+  }
+  if (payload.dat_webapp_collapsed === true) {
+    throw new UIIRGlassesAdapterError(
+      'DAT and Web App capability paths must not be collapsed',
+      'COLLAPSED_CAPABILITY_PATHS',
+    );
+  }
+  // Presence of forbidden raw sensor sample fields is always rejected.
+  if (hits.has('emg_raw') || hits.has('neural_band_raw')) {
+    throw new UIIRGlassesAdapterError(
+      'Raw EMG / neural stream fields are forbidden in glasses projection payloads',
+      'RAW_SENSOR_FORBIDDEN',
+    );
+  }
+}
+
+function isMandatory(item: GlassesSemanticItem): boolean {
+  return Boolean(item.mandatory) || MANDATORY_KINDS.has(item.semantic_kind);
+}
+
+function truncateText(text: string, limit: number): string {
+  if (limit <= 0) return '';
+  if (text.length <= limit) return text;
+  if (limit <= 1) return text.slice(0, limit);
+  return `${text.slice(0, limit - 1)}…`;
+}
+
+function surfaceFor(
+  item: GlassesSemanticItem,
+  disposition: GlassesDisposition,
+): GlassesSurfaceKind {
+  if (disposition === 'unsatisfiable') return 'unsatisfiable';
+  if (disposition === 'fallback') {
+    const fallbacks = item.fallback_capability_ids ?? [];
+    if (
+      item.fallback_ref?.startsWith('fallback:mobile') ||
+      fallbacks.includes('mobile_companion')
+    ) {
+      return 'mobile_fallback';
+    }
+    if (
+      item.fallback_ref?.startsWith('fallback:audio') ||
+      fallbacks.includes('audio') ||
+      fallbacks.includes('speech_output')
+    ) {
+      return 'audio_summary';
+    }
+    if (fallbacks.includes('notification')) return 'notification';
+    return 'mobile_fallback';
+  }
+  if (item.semantic_kind === 'confirmation') return 'confirmation';
+  if (item.semantic_kind === 'privacy' || item.semantic_kind === 'consent') {
+    return 'privacy_indicator';
+  }
+  if (item.semantic_kind === 'action') return 'action';
+  if (
+    item.semantic_kind === 'error' ||
+    item.semantic_kind === 'feedback' ||
+    item.semantic_kind === 'consequence'
+  ) {
+    return 'status';
+  }
+  return 'hud_card';
+}
+
+function sortItems(items: readonly GlassesSemanticItem[]): GlassesSemanticItem[] {
+  return [...items].sort((a, b) => {
+    const pa = a.priority ?? 100;
+    const pb = b.priority ?? 100;
+    if (pa !== pb) return pa - pb;
+    return a.item_id.localeCompare(b.item_id);
+  });
+}
+
+/**
+ * Project semantic UI/UX IR items onto a Meta-glasses spatial presentation.
+ */
+export function projectUIIRToGlasses(
+  request: GlassesProjectionRequest,
+): UIIRGlassesProjection {
+  if (!request || typeof request !== 'object') {
+    throw new UIIRGlassesAdapterError(
+      'Glasses projection request must be an object',
+      'INVALID_REQUEST',
+    );
+  }
+  if (!Array.isArray(request.items) || request.items.length === 0) {
+    throw new UIIRGlassesAdapterError(
+      'Glasses projection requires a non-empty items list',
+      'EMPTY_ITEMS',
+    );
+  }
+
+  const capabilityPath = request.capability_path ?? 'web_app';
+  const profile = glassesCapabilityProfile(capabilityPath);
+  rejectFabricatedCapabilityClaims({
+    continuous_cursor: profile.continuous_cursor,
+    freeform_touch: profile.freeform_touch,
+    continuous_text_input: profile.continuous_text_input,
+    raw_emg: profile.raw_emg,
+    dat_webapp_collapsed: false,
+  });
+
+  const budgets = profile.budgets;
+  const ordered = sortItems(request.items);
+  const nodes: GlassesPresentationNode[] = [];
+  const losses: GlassesLossEntry[] = [];
+  let actionUsed = 0;
+  let textUsed = 0;
+  let updateUsed = 0;
+  let fovUsed = 0;
+  let attentionUsed = 0;
+  let focusCounter = 0;
+  let hasFallback = false;
+  let hasDegraded = false;
+  let hasUnsat = false;
+
+  // Soft pass: place survival semantics first (privacy/confirmation), then others.
+  const survival = ordered.filter(
+    item => SURVIVAL_KINDS.has(item.semantic_kind) || isMandatory(item),
+  );
+  const optional = ordered.filter(
+    item => !SURVIVAL_KINDS.has(item.semantic_kind) && !isMandatory(item),
+  );
+  const placementOrder = [...survival, ...optional];
+
+  for (const [index, item] of placementOrder.entries()) {
+    if (!item.item_id || !item.semantic_kind) {
+      throw new UIIRGlassesAdapterError(
+        'Each glasses projection item requires item_id and semantic_kind',
+        'INVALID_ITEM',
+      );
+    }
+
+    const mandatory = isMandatory(item);
+    const actionCost = item.action_cost ?? (item.semantic_kind === 'action' ? 1 : 0);
+    const textChars =
+      item.text_chars ??
+      Math.max(8, (item.label ?? item.text ?? item.item_id).length);
+    const updateRate = item.update_rate ?? 0;
+    const fovShare = item.field_of_view_share ?? (mandatory ? 8 : 4);
+    const attention = item.attention_cost ?? (mandatory ? 5 : 1);
+    const label = item.label ?? item.text ?? item.item_id;
+
+    const wouldExceed =
+      actionUsed + actionCost > budgets.action_count ||
+      textUsed + textChars > budgets.text_chars ||
+      Math.max(updateUsed, updateRate) > budgets.update_hz ||
+      fovUsed + fovShare > budgets.field_of_view ||
+      attentionUsed + attention > budgets.attention;
+
+    let disposition: GlassesDisposition = 'preserved';
+    let surface: GlassesSurfaceKind;
+    let fallbackRef = item.fallback_ref ?? '';
+
+    // Continuous text input is never assumed: text-entry items fall back/fail.
+    if (item.semantic_kind === 'text_input' || item.semantic_kind === 'freeform_text') {
+      if (mandatory) {
+        disposition = 'fallback';
+        fallbackRef = fallbackRef || `fallback:mobile:${item.item_id}`;
+        hasFallback = true;
+        losses.push({
+          loss_id: `loss:fallback-text:${item.item_id}`,
+          semantic_id: item.item_id,
+          semantic_kind: item.semantic_kind,
+          category: 'fallback',
+          reason:
+            'Continuous text input is not assumed on glasses; routing to mobile companion',
+          mandatory: true,
+          fallback_ref: fallbackRef,
+        });
+      } else {
+        disposition = 'omitted';
+        losses.push({
+          loss_id: `loss:omit-text:${item.item_id}`,
+          semantic_id: item.item_id,
+          semantic_kind: item.semantic_kind,
+          category: 'omitted',
+          reason: 'Optional free-form text omitted; continuous text input not assumed',
+          mandatory: false,
+        });
+      }
+    } else if (wouldExceed) {
+      if (mandatory) {
+        disposition = 'fallback';
+        fallbackRef =
+          fallbackRef ||
+          (item.fallback_capability_ids?.includes('audio')
+            ? `fallback:audio:${item.item_id}`
+            : `fallback:mobile:${item.item_id}`);
+        hasFallback = true;
+        losses.push({
+          loss_id: `loss:fallback-budget:${item.item_id}`,
+          semantic_id: item.item_id,
+          semantic_kind: item.semantic_kind,
+          category: 'fallback',
+          reason:
+            'Mandatory semantic projected via mobile/audio fallback to respect glasses budgets',
+          mandatory: true,
+          fallback_ref: fallbackRef,
+          budget_kind: 'action_count',
+        });
+      } else {
+        disposition = 'omitted';
+        hasDegraded = true;
+        losses.push({
+          loss_id: `loss:omit-budget:${item.item_id}`,
+          semantic_id: item.item_id,
+          semantic_kind: item.semantic_kind,
+          category: 'omitted',
+          reason: 'Optional item omitted to respect glasses action/text/FOV budgets',
+          mandatory: false,
+          budget_kind: 'field_of_view',
+        });
+      }
+    } else {
+      // Fits on spatial display.
+      actionUsed += actionCost;
+      textUsed += textChars;
+      updateUsed = Math.max(updateUsed, updateRate);
+      fovUsed += fovShare;
+      attentionUsed += attention;
+    }
+
+    // Survival kinds that somehow became omitted without policy → unsatisfiable.
+    if (
+      disposition === 'omitted' &&
+      mandatory &&
+      SURVIVAL_KINDS.has(item.semantic_kind)
+    ) {
+      disposition = 'unsatisfiable';
+      hasUnsat = true;
+      losses.push({
+        loss_id: `loss:unsat-survival:${item.item_id}`,
+        semantic_id: item.item_id,
+        semantic_kind: item.semantic_kind,
+        category: 'unsatisfiable',
+        reason:
+          'Privacy/confirmation semantics cannot be silently omitted on glasses',
+        mandatory: true,
+      });
+    }
+
+    surface = surfaceFor(item, disposition);
+
+    // Fallback surfaces do not consume HUD action slots but remain present.
+    if (disposition === 'fallback' || disposition === 'preserved' || disposition === 'adapted' || disposition === 'summarized') {
+      // already handled usage for preserved path
+    }
+
+    let actionId = '';
+    let focusIndex: number | null = null;
+    if (
+      surface === 'action' &&
+      disposition !== 'omitted' &&
+      disposition !== 'unsatisfiable'
+    ) {
+      actionId = item.item_id;
+      focusIndex = focusCounter;
+      focusCounter += 1;
+    }
+
+    nodes.push({
+      node_id: `glasses:${item.item_id}`,
+      surface,
+      semantic_id: item.item_id,
+      semantic_kind: item.semantic_kind,
+      disposition,
+      mandatory,
+      order: index,
+      label,
+      text: truncateText(label, budgets.text_chars),
+      action_id: actionId,
+      focus_index: focusIndex,
+      fallback_ref: fallbackRef,
+      component_id: item.component_id ?? '',
+    });
+  }
+
+  // Explicit unsupported-assumption receipts.
+  for (const assumption of UNSUPPORTED_GLASSES_ASSUMPTIONS) {
+    losses.push({
+      loss_id: `loss:unsupported-assumption:${assumption}`,
+      semantic_id: `assumption:${assumption}`,
+      semantic_kind: 'capability_assumption',
+      category: 'unsupported',
+      reason: `Glasses projection never fabricates ${assumption}; path=${capabilityPath}`,
+      mandatory: false,
+      details: [`capability_path=${capabilityPath}`],
+    });
+  }
+
+  // Fail closed: every survival semantic must appear as node or loss.
+  for (const item of ordered) {
+    if (!SURVIVAL_KINDS.has(item.semantic_kind) && !isMandatory(item)) continue;
+    if (!MANDATORY_KINDS.has(item.semantic_kind) && !isMandatory(item)) continue;
+    const covered =
+      nodes.some(
+        n =>
+          n.semantic_id === item.item_id &&
+          n.disposition !== 'omitted',
+      ) || losses.some(l => l.semantic_id === item.item_id);
+    if (!covered && isMandatory(item)) {
+      hasUnsat = true;
+      losses.push({
+        loss_id: `loss:unsat-missing:${item.item_id}`,
+        semantic_id: item.item_id,
+        semantic_kind: item.semantic_kind,
+        category: 'unsatisfiable',
+        reason: 'Mandatory semantic missing explicit preserve/fallback/loss receipt',
+        mandatory: true,
+      });
+      nodes.push({
+        node_id: `glasses:unsat:${item.item_id}`,
+        surface: 'unsatisfiable',
+        semantic_id: item.item_id,
+        semantic_kind: item.semantic_kind,
+        disposition: 'unsatisfiable',
+        mandatory: true,
+        order: nodes.length,
+        label: item.label ?? item.item_id,
+        text: item.label ?? item.item_id,
+        action_id: '',
+        focus_index: null,
+        fallback_ref: item.fallback_ref ?? '',
+        component_id: item.component_id ?? '',
+      });
+    }
+  }
+
+  const exceeded: string[] = [];
+  if (actionUsed > budgets.action_count) exceeded.push('action_count');
+  if (textUsed > budgets.text_chars) exceeded.push('text_density');
+  if (updateUsed > budgets.update_hz) exceeded.push('update_rate');
+  if (fovUsed > budgets.field_of_view) exceeded.push('field_of_view');
+
+  let status: GlassesProjectionStatus = 'satisfied';
+  if (hasUnsat) status = 'unsatisfiable';
+  else if (hasFallback) status = 'fallback';
+  else if (hasDegraded || exceeded.length > 0) status = 'degraded';
+
+  const budgetReceipt: GlassesBudgetReceipt = {
+    action_count: actionUsed,
+    action_limit: budgets.action_count,
+    text_chars: textUsed,
+    text_limit: budgets.text_chars,
+    update_hz: updateUsed,
+    update_limit: budgets.update_hz,
+    field_of_view_share: fovUsed,
+    field_of_view_limit: budgets.field_of_view,
+    exceeded,
+  };
+
+  const capabilityReceipt: GlassesCapabilityReceipt = {
+    capability_path: capabilityPath,
+    profile_id: profile.profile_id,
+    render_path: profile.render_path,
+    input_capability_ids: [...profile.input_capability_ids].sort(),
+    output_capability_ids: [...profile.output_capability_ids].sort(),
+    unsupported_assumptions: UNSUPPORTED_GLASSES_ASSUMPTIONS,
+    dat_webapp_collapsed: false,
+  };
+
+  const compilerHandoff = buildCompilerHandoff(
+    nodes,
+    capabilityPath,
+    profile,
+    budgetReceipt,
+    request.title,
+  );
+
+  const documentId = request.document_id ?? '';
+  const projectionId =
+    request.projection_id ??
+    `glasses:${capabilityPath}:${documentId || 'anon'}:${nodes.length}`;
+
+  return {
+    interface: UIIR_GLASSES_PROJECTION_INTERFACE,
+    schema_version: UIIR_GLASSES_PROJECTION_SCHEMA_VERSION,
+    projection_id: projectionId,
+    document_id: documentId,
+    profile_id: profile.profile_id,
+    capability_path: capabilityPath,
+    status,
+    nodes,
+    input_bindings: defaultInputBindings(capabilityPath),
+    losses: losses.sort((a, b) => a.loss_id.localeCompare(b.loss_id)),
+    budget_receipt: budgetReceipt,
+    capability_receipt: capabilityReceipt,
+    compiler_handoff: compilerHandoff,
+  };
+}
+
+function buildCompilerHandoff(
+  nodes: readonly GlassesPresentationNode[],
+  capabilityPath: GlassesCapabilityPath,
+  profile: GlassesCapabilityProfile,
+  budget: GlassesBudgetReceipt,
+  title?: string,
+): GlassesCompilerHandoff {
+  const actions: GlassesCompilerHandoff['actions'][number][] = [];
+  const regions: Record<string, unknown>[] = [
+    {
+      id: 'title',
+      kind: 'text',
+      text: {
+        value: title ?? 'UI/UX IR Glasses Projection',
+        max_chars: 40,
+        max_lines: 1,
+      },
+    },
+  ];
+  const focusOrder: string[] = [];
+  const fallbacks: Record<string, unknown>[] = [];
+
+  for (const node of [...nodes].sort((a, b) => a.order - b.order)) {
+    if (node.disposition === 'omitted') continue;
+    if (node.disposition === 'unsatisfiable') {
+      fallbacks.push({
+        when: ['unsatisfiable_mandatory'],
+        render_path: 'notification',
+        message: `Cannot present ${node.semantic_id} on glasses`,
+        semantic_id: node.semantic_id,
+      });
+      continue;
+    }
+    if (node.surface === 'action') {
+      const actionId = node.action_id || node.semantic_id;
+      actions.push({
+        id: actionId,
+        method: actionId,
+        backend_action_id: node.semantic_id,
+        label: truncateText(node.label || actionId, 12),
+        focusable: true,
+      });
+      focusOrder.push(actionId);
+      regions.push({
+        id: `action:${actionId}`,
+        kind: 'action',
+        action_id: actionId,
+        text: {
+          value: node.text,
+          max_chars: Math.min(40, budget.text_limit),
+          max_lines: 1,
+        },
+      });
+    } else if (node.surface === 'confirmation') {
+      regions.push({
+        id: `confirm:${node.semantic_id}`,
+        kind: 'status',
+        text: {
+          value: node.text || 'Confirm',
+          max_chars: Math.min(80, budget.text_limit),
+          max_lines: 2,
+        },
+        visible_if: 'confirmation_required',
+      });
+    } else if (node.surface === 'privacy_indicator') {
+      regions.push({
+        id: `privacy:${node.semantic_id}`,
+        kind: 'status',
+        text: {
+          value: node.text || 'Privacy',
+          max_chars: Math.min(60, budget.text_limit),
+          max_lines: 1,
+        },
+        visible_if: 'privacy_active',
+      });
+    } else if (node.surface === 'mobile_fallback') {
+      fallbacks.push({
+        when: ['display_unsupported', 'budget_exceeded'],
+        render_path: 'mobile-card',
+        message: node.text || 'Continue on phone',
+        semantic_id: node.semantic_id,
+      });
+    } else if (node.surface === 'audio_summary') {
+      fallbacks.push({
+        when: ['display_unsupported'],
+        render_path: 'audio-summary',
+        message: node.text || 'Audio summary',
+        semantic_id: node.semantic_id,
+      });
+    } else {
+      regions.push({
+        id: `region:${node.semantic_id}`,
+        kind: node.surface === 'status' ? 'status' : 'text',
+        text: {
+          value: node.text,
+          max_chars: Math.min(80, budget.text_limit),
+          max_lines: 2,
+        },
+      });
+    }
+  }
+
+  if (fallbacks.length === 0) {
+    fallbacks.push({
+      when: ['dat_native_display_unavailable', 'session_not_ready'],
+      render_path: 'mobile-card',
+      message: 'View on phone',
+    });
+  }
+
+  const template = nodes.some(n => n.surface === 'confirmation')
+    ? 'confirmation'
+    : actions.length <= 1
+      ? 'single-card'
+      : 'stack';
+
+  const inputKinds =
+    capabilityPath === 'dat'
+      ? ['dpad', 'gesture', 'voice', 'mobile_action']
+      : ['dpad', 'voice', 'mobile_action'];
+
+  return {
+    template,
+    render_path: profile.render_path,
+    max_actions: profile.budgets.action_count,
+    max_text_chars: budget.text_limit,
+    max_update_hz: budget.update_limit,
+    focus_order: focusOrder.slice(0, profile.budgets.action_count),
+    actions: actions.slice(0, profile.budgets.action_count),
+    regions,
+    fallbacks,
+    input_kinds: inputKinds,
+  };
+}
+
+export function normalizeGlassesIntent(
+  token: string,
+  options: {
+    source?: GlassesInputSource;
+    capability_path?: GlassesCapabilityPath;
+  } = {},
+): GlassesIntentNormalizationResult {
+  const source = options.source ?? 'neural_band';
+  const capabilityPath = options.capability_path ?? 'web_app';
+  if (source !== 'neural_band' && source !== 'captouch' && source !== 'dpad') {
+    throw new UIIRGlassesAdapterError(
+      `Intent normalization for source ${source} is not Arrow/Enter-mapped in this adapter`,
+      'UNSUPPORTED_SOURCE',
+    );
+  }
+  const intent = normalizeArrowEnterIntent(token);
+  return {
+    token,
+    intent,
+    source,
+    capability_path: capabilityPath,
+    raw_emg: false,
+    continuous_cursor: false,
+  };
+}
+
+export class UIIRGlassesAdapter {
+  readonly interface = UIIR_GLASSES_ADAPTER_INTERFACE;
+  readonly capabilityPath: GlassesCapabilityPath;
+
+  constructor(capabilityPath: GlassesCapabilityPath = 'web_app') {
+    this.capabilityPath = capabilityPath;
+    // Validate path early.
+    glassesCapabilityProfile(capabilityPath);
+  }
+
+  profile(): GlassesCapabilityProfile {
+    return glassesCapabilityProfile(this.capabilityPath);
+  }
+
+  inputBindings(): GlassesInputBinding[] {
+    return defaultInputBindings(this.capabilityPath);
+  }
+
+  project(request: GlassesProjectionRequest): UIIRGlassesProjection {
+    return projectUIIRToGlasses({
+      ...request,
+      capability_path: request.capability_path ?? this.capabilityPath,
+    });
+  }
+
+  normalizeIntent(
+    token: string,
+    source: GlassesInputSource = 'neural_band',
+  ): GlassesIntentNormalizationResult {
+    return normalizeGlassesIntent(token, {
+      source,
+      capability_path: this.capabilityPath,
+    });
+  }
+}
+
+export default UIIRGlassesAdapter;

--- a/src/services/ipfs/mcp-ipfs-kit-tools-manifest.json
+++ b/src/services/ipfs/mcp-ipfs-kit-tools-manifest.json
@@ -545,6 +545,30 @@
       ],
       "deprecated": false,
       "category": "stats_tools"
+    },
+    {
+      "name": "iroh_diagnostics",
+      "description": "Return a redacted Iroh health receipt or bounded-label metrics.\n\n    Iroh diagnostics live in the optional managed-Iroh integration, which\n    pulls in the application's HTTP stack.  Keep that import at execution\n    time so constructing the core MCP server remains usable from a minimal\n    wheel without FastAPI installed.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "instance": {
+            "type": "string",
+            "default": "default"
+          },
+          "format": {
+            "type": "string",
+            "default": "health"
+          },
+          "persist": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "tags": [],
+      "deprecated": false,
+      "category": "iroh_tools"
     }
   ]
 }

--- a/src/services/mcp/mcp-control-surface-mediator.ts
+++ b/src/services/mcp/mcp-control-surface-mediator.ts
@@ -141,11 +141,43 @@ export interface ControlSurfaceORBLikeBinding {
   };
 }
 
+export interface ControlSurfaceUIIRIdentity {
+  /** Content id of the UI/UX IR declaration (never equated with interface_cid). */
+  ui_ir_cid?: string;
+  action_id?: string;
+  component_id?: string;
+  state_id?: string;
+  program_binding_id?: string;
+  mcp_idl_binding_id?: string;
+  /**
+   * Advisory presentation only. Visibility/enabled never authorizes; the
+   * mediator always re-evaluates formal policy with the current real input.
+   * Any explicit authorization claim (authorizes/authorized/permit/outcome)
+   * fails closed before the policy evaluator runs.
+   */
+  presentation?: {
+    visibility?: 'hidden' | 'disabled' | 'enabled' | string;
+    enabled?: boolean;
+    hidden?: boolean;
+    /** Explicit claim — always rejected (presentation never authorizes). */
+    authorizes?: boolean;
+    authorized?: boolean;
+    permit?: boolean;
+    outcome?: string;
+  };
+}
+
 export interface ControlSurfaceInvocationContext {
   correlation_id?: string;
   caller_did?: string;
   metadata?: Record<string, unknown>;
   control_surface?: Record<string, unknown>;
+  /** Optional deontic / Profile-D policy identity required for UIIR mediation. */
+  policy_cid?: string;
+  /** Optional runtime state identity retained on receipts. */
+  state_id?: string;
+  /** UIIR identity bundle for governed mediation (UIR-033). */
+  uiir?: ControlSurfaceUIIRIdentity;
 }
 
 export interface ControlSurfaceMediationRequest {
@@ -153,6 +185,11 @@ export interface ControlSurfaceMediationRequest {
   input: unknown;
   context: ControlSurfaceInvocationContext;
   policy_evaluator?: ControlSurfacePolicyEvaluator;
+  /**
+   * When true (or when `context.uiir.ui_ir_cid` is set), policy identity and
+   * current real input are mandatory and presentation cannot authorize.
+   */
+  require_uiir_mediation?: boolean;
 }
 
 export interface ControlSurfacePolicyEvaluationRequest {
@@ -293,6 +330,33 @@ export interface ControlSurfaceMediationResult {
   mediation_receipt: ControlSurfaceMediationReceipt;
   can_invoke: boolean;
   invocation_input: unknown;
+  /** Retained actor/delegation/UI/action/IDL/policy/state/decision identities. */
+  retained_identities?: ControlSurfaceRetainedIdentities;
+}
+
+/**
+ * Stable identity fields retained across mediation → ORB invocation receipts.
+ * Presentation visibility is intentionally excluded (never authorizes).
+ */
+export interface ControlSurfaceRetainedIdentities {
+  actor_id?: string;
+  delegation_chain?: string[];
+  ui_ir_cid?: string;
+  action_id?: string;
+  component_id?: string;
+  interface_cid?: string;
+  policy_cid?: string;
+  policy_bundle_id?: string;
+  policy_bundle_cid?: string;
+  compiled_policy_cid?: string;
+  state_id?: string;
+  decision_id?: string;
+  decision_cid?: string;
+  invocation_id?: string;
+  correlation_id?: string;
+  program_binding_id?: string;
+  mcp_idl_binding_id?: string;
+  interaction_id?: string;
 }
 
 interface ControlSurfaceMediationBase {
@@ -431,10 +495,28 @@ export function ensureControlSurfaceContract<T extends ControlSurfaceEnvelopeDes
 export async function control_surface_mediator(
   request: ControlSurfaceMediationRequest,
 ): Promise<ControlSurfaceMediationResult> {
+  return mediateControlSurfaceInvocation(request);
+}
+
+/**
+ * ControlSurfaceMediation@1 entry point. Every candidate action is evaluated
+ * against the current policy with the real bounded input. Presentation
+ * visibility never authorizes; missing policy identity under UIIR mediation
+ * fails closed before transport.
+ */
+export async function mediateControlSurfaceInvocation(
+  request: ControlSurfaceMediationRequest,
+): Promise<ControlSurfaceMediationResult> {
   const descriptor = ensureControlSurfaceContract(request.binding.descriptor);
   const contract = descriptor.control_surface_contract as ControlSurfaceContract;
   const method = request.binding.operation.method;
   const surfaceContext = resolveSurfaceContext(request.context, request.input);
+  const uiirIdentity = resolveUIIRIdentity(request);
+  const uiirMediation = Boolean(
+    request.require_uiir_mediation
+    || uiirIdentity.ui_ir_cid
+    || uiirIdentity.action_id,
+  );
   const surface = contract.control_surfaces.find(candidate => candidate.id === surfaceContext.surface);
   const intentBinding = contract.intent_bindings.find(candidate => candidate.method === method);
   const selectedLogicBindings = selectedLogicBindingsFor(contract, surface, intentBinding, surfaceContext.surface, method);
@@ -474,6 +556,17 @@ export async function control_surface_mediator(
     })),
   };
 
+  // Presentation never authorizes: reject any attempt to skip policy via UI state.
+  const presentationReasons = presentationAuthorizationDenialReasons(uiirIdentity.presentation);
+  const uiirGateReasons = uiirMediation
+    ? uiirMediationDenialReasons(request, uiirIdentity)
+    : [];
+  const prePolicyReasons = [
+    ...descriptorReasons,
+    ...presentationReasons,
+    ...uiirGateReasons,
+  ];
+
   const policyDecisionContext = {
     request,
     contract,
@@ -482,7 +575,7 @@ export async function control_surface_mediator(
     compiledPolicyCid,
     controlSurfaceContractRef,
     selectedLogicBindings,
-    descriptorReasons,
+    descriptorReasons: prePolicyReasons,
     method,
     targetRef,
     args,
@@ -502,14 +595,195 @@ export async function control_surface_mediator(
     now,
   });
 
+  const effect = policyDecision.effects[0];
+  const canInvoke = canInvokeControlSurfaceOutcome(policyDecision.outcome);
+  // rewrite/fallback may adjust arguments; still never invent a permit from presentation.
+  const invocationInput = canInvoke && effect && Object.keys(objectPayload(effect.arguments)).length > 0
+    ? effect.arguments
+    : request.input;
+
+  const retainedIdentities = retainControlSurfaceIdentities({
+    actor_id: surfaceContext.actor.id,
+    delegation_chain: surfaceContext.actor.delegation_chain,
+    ui_ir_cid: uiirIdentity.ui_ir_cid,
+    action_id: uiirIdentity.action_id,
+    component_id: uiirIdentity.component_id,
+    interface_cid: request.binding.interface_cid,
+    policy_cid: request.context.policy_cid,
+    policy_bundle_id: policyDecision.policy_bundle_ref.policy_id,
+    policy_bundle_cid: policyDecision.policy_bundle_ref.policy_cid,
+    compiled_policy_cid: policyDecision.compiled_policy_cid,
+    state_id: uiirIdentity.state_id ?? request.context.state_id,
+    decision_id: policyDecision.decision_id,
+    invocation_id: request.context.correlation_id
+      ?? interactionEnvelope.interaction_id,
+    correlation_id: request.context.correlation_id,
+    program_binding_id: uiirIdentity.program_binding_id,
+    mcp_idl_binding_id: uiirIdentity.mcp_idl_binding_id,
+    interaction_id: interactionEnvelope.interaction_id,
+  });
+
+  // Stamp retained identities onto the receipt metadata for end-to-end correlation.
+  mediationReceipt.metadata = {
+    ...mediationReceipt.metadata,
+    retained_identities: retainedIdentities,
+    uiir_mediation: uiirMediation,
+    presentation_never_authorizes: true,
+  };
+  policyDecision.metadata = {
+    ...policyDecision.metadata,
+    retained_identities: retainedIdentities,
+    uiir_mediation: uiirMediation,
+    presentation_never_authorizes: true,
+  };
+
   return {
     control_surface_contract_ref: controlSurfaceContractRef,
     interaction_envelope: interactionEnvelope,
     policy_decision: policyDecision,
     mediation_receipt: mediationReceipt,
-    can_invoke: canInvokeControlSurfaceOutcome(policyDecision.outcome),
-    invocation_input: request.input,
+    can_invoke: canInvoke,
+    invocation_input: invocationInput,
+    retained_identities: retainedIdentities,
   };
+}
+
+/**
+ * Explicit adapter: existing non-UIIR descriptors stay compatible by routing
+ * through the same fail-closed mediator without requiring a ui_ir_cid.
+ */
+export async function mediateLegacyControlSurfaceInvocation(
+  request: ControlSurfaceMediationRequest,
+): Promise<ControlSurfaceMediationResult> {
+  return mediateControlSurfaceInvocation({
+    ...request,
+    require_uiir_mediation: false,
+    context: {
+      ...request.context,
+      uiir: undefined,
+    },
+  });
+}
+
+function resolveUIIRIdentity(request: ControlSurfaceMediationRequest): ControlSurfaceUIIRIdentity {
+  const fromContext = request.context.uiir ?? {};
+  const metadata = objectPayload(request.context.metadata);
+  const metadataUiir = objectPayload(metadata.uiir);
+  const controlSurface = objectPayload(request.context.control_surface);
+  return {
+    ui_ir_cid: stringFrom(fromContext.ui_ir_cid)
+      ?? stringFrom(metadataUiir.ui_ir_cid)
+      ?? stringFrom(metadata.ui_ir_cid)
+      ?? stringFrom(controlSurface.ui_ir_cid),
+    action_id: stringFrom(fromContext.action_id)
+      ?? stringFrom(metadataUiir.action_id)
+      ?? stringFrom(metadata.action_id)
+      ?? stringFrom(controlSurface.action_id),
+    component_id: stringFrom(fromContext.component_id)
+      ?? stringFrom(metadataUiir.component_id)
+      ?? stringFrom(metadata.component_id),
+    state_id: stringFrom(fromContext.state_id)
+      ?? stringFrom(request.context.state_id)
+      ?? stringFrom(metadataUiir.state_id)
+      ?? stringFrom(metadata.state_id),
+    program_binding_id: stringFrom(fromContext.program_binding_id)
+      ?? stringFrom(metadataUiir.program_binding_id),
+    mcp_idl_binding_id: stringFrom(fromContext.mcp_idl_binding_id)
+      ?? stringFrom(metadataUiir.mcp_idl_binding_id),
+    presentation: fromContext.presentation
+      ?? (isRecord(metadataUiir.presentation) ? metadataUiir.presentation as ControlSurfaceUIIRIdentity['presentation'] : undefined)
+      ?? (isRecord(metadata.presentation) ? metadata.presentation as ControlSurfaceUIIRIdentity['presentation'] : undefined)
+      ?? (isRecord(controlSurface.presentation) ? controlSurface.presentation as ControlSurfaceUIIRIdentity['presentation'] : undefined),
+  };
+}
+
+/**
+ * Presentation is advisory. Any attempt to claim authorization from
+ * visibility/enabled/hidden fails closed before the policy evaluator runs.
+ */
+function presentationAuthorizationDenialReasons(
+  presentation: ControlSurfaceUIIRIdentity['presentation'] | undefined,
+): string[] {
+  if (!presentation) {
+    return [];
+  }
+  const claimedAuth = presentation.authorizes === true
+    || presentation.authorized === true
+    || presentation.permit === true
+    || presentation.outcome === 'permit'
+    || presentation.outcome === 'allow'
+    || presentation.outcome === 'PERMIT';
+  if (claimedAuth) {
+    return [
+      'UIIR presentation claimed authorization; hidden/enabled presentation never authorizes transport.',
+    ];
+  }
+  // Visibility alone is never a denial or grant — only explicit authorization claims fail.
+  return [];
+}
+
+/**
+ * UIIR mediation requires policy identity and a real current input. Missing
+ * either fails closed so input-sensitive and policy-bound rules cannot be
+ * bypassed.
+ */
+function uiirMediationDenialReasons(
+  request: ControlSurfaceMediationRequest,
+  uiirIdentity: ControlSurfaceUIIRIdentity,
+): string[] {
+  const reasons: string[] = [];
+  const policyCid = stringFrom(request.context.policy_cid)
+    ?? stringFrom(objectPayload(request.context.metadata).policy_cid);
+  if (!policyCid) {
+    reasons.push(
+      'UIIR mediation requires policy identity (policy_cid) for unary and streaming authorization.',
+    );
+  }
+  if (!hasRealMediationInput(request.input)) {
+    reasons.push(
+      'UIIR mediation requires the current real input; empty/missing input fails closed before transport.',
+    );
+  }
+  if (!uiirIdentity.ui_ir_cid && !uiirIdentity.action_id && request.require_uiir_mediation) {
+    reasons.push(
+      'UIIR mediation requires ui_ir_cid or action_id identity bindings.',
+    );
+  }
+  return reasons;
+}
+
+function hasRealMediationInput(input: unknown): boolean {
+  if (input === null || input === undefined) {
+    return false;
+  }
+  if (typeof input === 'string') {
+    return input.length > 0;
+  }
+  if (typeof input === 'number' || typeof input === 'boolean') {
+    return true;
+  }
+  if (Array.isArray(input)) {
+    return input.length > 0;
+  }
+  if (isRecord(input)) {
+    return Object.keys(input).length > 0;
+  }
+  return true;
+}
+
+function retainControlSurfaceIdentities(
+  partial: ControlSurfaceRetainedIdentities,
+): ControlSurfaceRetainedIdentities {
+  const retained: ControlSurfaceRetainedIdentities = {};
+  for (const [key, value] of Object.entries(partial) as Array<
+    [keyof ControlSurfaceRetainedIdentities, ControlSurfaceRetainedIdentities[keyof ControlSurfaceRetainedIdentities]]
+  >) {
+    if (value === undefined) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    if (typeof value === 'string' && value.length === 0) continue;
+    (retained as Record<string, unknown>)[key] = Array.isArray(value) ? [...value] : value;
+  }
+  return retained;
 }
 
 interface PolicyDecisionContext {

--- a/src/services/mcp/mcp-deontic-interface-broker.ts
+++ b/src/services/mcp/mcp-deontic-interface-broker.ts
@@ -562,6 +562,247 @@ export function createDeonticORBEvaluator(
 }
 
 // ---------------------------------------------------------------------------
+// UIIRORBBridge@1 — UI/UX IR bindings feed presentation, never authorization
+// ---------------------------------------------------------------------------
+
+/** Stable interface id for the UIIR ↔ deontic/ORB bridge (UIR-033). */
+export const UIIR_ORB_BRIDGE_INTERFACE = 'UIIRORBBridge@1' as const;
+
+/**
+ * Presentation classification projected onto a control. Advisory only: the
+ * runtime must re-evaluate formal policy on every invocation and must never
+ * treat visibility/enabled as a permit.
+ */
+export type UIIRPresentationVisibility = 'hidden' | 'disabled' | 'enabled';
+
+export interface UIIRPresentationState {
+  visibility: UIIRPresentationVisibility;
+  /** Deontic UI outcome for generators — not an authorization decision. */
+  deontic_outcome?: 'permit' | 'deny' | 'unavailable';
+  reasons?: string[];
+}
+
+/**
+ * Identity bundle retained end-to-end on mediation/invocation receipts.
+ * Presentation fields are intentionally absent: they never authorize.
+ */
+export interface UIIRMediationIdentity {
+  actor_id?: string;
+  delegation_chain?: string[];
+  ui_ir_cid?: string;
+  action_id?: string;
+  component_id?: string;
+  interface_cid?: string;
+  policy_cid?: string;
+  state_id?: string;
+  decision_id?: string;
+  decision_cid?: string;
+  invocation_id?: string;
+  correlation_id?: string;
+  program_binding_id?: string;
+  mcp_idl_binding_id?: string;
+}
+
+export interface UIIRActionBinding {
+  action_id: string;
+  method: string;
+  interface_cid: string;
+  ui_ir_cid?: string;
+  component_id?: string;
+  program_binding_id?: string;
+  mcp_idl_binding_id?: string;
+  /** Advisory presentation only — never used as an authorization grant. */
+  presentation: UIIRPresentationState;
+  deontic_state: DeonticOperationState;
+  decision_cid: string;
+  capability: string;
+  resource: string;
+  reasons: string[];
+  obligations: ActiveObligation[];
+}
+
+export interface UIIRORBBridgeProjection {
+  interface: typeof UIIR_ORB_BRIDGE_INTERFACE;
+  ui_ir_cid?: string;
+  interface_cid: string;
+  policy_cid: string;
+  /** True when this projection came from an explicit non-UIIR adapter. */
+  legacy_adapter: boolean;
+  actions: UIIRActionBinding[];
+  /** Ready for schema-driven UI generators; never authorizes transport. */
+  policy_decisions: Record<string, GeneratedUIPolicyDecision>;
+  projection: DeonticInterfaceProjection;
+}
+
+export interface ProjectUIIRDeonticOptions {
+  context?: DeonticProjectionContext;
+  engine?: PolicyEngine;
+  /** Optional content id of the UIIR declaration (distinct from interface_cid). */
+  ui_ir_cid?: string;
+  /**
+   * Optional map of method → action identity. When omitted, stable action ids
+   * are derived from method names.
+   */
+  action_ids?: Record<string, string>;
+  component_ids?: Record<string, string>;
+  program_binding_ids?: Record<string, string>;
+  mcp_idl_binding_ids?: Record<string, string>;
+}
+
+/**
+ * Map a deontic method projection to advisory presentation visibility.
+ *
+ * Hidden/disabled/enabled is presentation only. Callers must still authorize
+ * through the control-surface mediator + ORB path with policy identity and
+ * the current real input.
+ */
+export function presentationStateFromDeontic(
+  state: DeonticOperationState,
+  reasons: string[] = [],
+): UIIRPresentationState {
+  switch (state) {
+    case 'prohibited':
+      return { visibility: 'hidden', deontic_outcome: 'deny', reasons };
+    case 'unavailable':
+      return { visibility: 'disabled', deontic_outcome: 'unavailable', reasons };
+    case 'obligated':
+    case 'permitted':
+      return {
+        visibility: 'enabled',
+        deontic_outcome: 'permit',
+        reasons: reasons.length > 0 ? reasons : undefined,
+      };
+    default:
+      return { visibility: 'disabled', deontic_outcome: 'unavailable', reasons };
+  }
+}
+
+/**
+ * Fail closed if a caller attempts to treat presentation visibility as an
+ * authorization grant. Enabled/hidden never authorize transport.
+ */
+export function assertPresentationDoesNotAuthorize(
+  presentation: UIIRPresentationState | Record<string, unknown> | undefined,
+  claimedOutcome?: string,
+): { authorized: false; reasons: string[] } {
+  const visibility = typeof presentation === 'object' && presentation
+    ? String((presentation as { visibility?: unknown }).visibility ?? '')
+    : '';
+  const reasons = [
+    'UIIR presentation is advisory only and never authorizes transport invocation.',
+  ];
+  if (visibility === 'enabled' || visibility === 'hidden' || visibility === 'disabled') {
+    reasons.push(`Presentation visibility "${visibility}" cannot grant or deny runtime authorization.`);
+  }
+  if (claimedOutcome === 'permit' || claimedOutcome === 'allow' || claimedOutcome === 'PERMIT') {
+    reasons.push('Presentation-claimed permit is rejected; re-evaluate formal policy with current input.');
+  }
+  return { authorized: false, reasons };
+}
+
+/**
+ * Project an MCP-IDL interface + formal policy into UIIRORBBridge@1 action
+ * bindings. Presentation state is derived for UI generation only; every
+ * subsequent invoke must re-evaluate the current policy with real input.
+ */
+export function projectUIIRDeonticInterface(
+  descriptor: InterfaceDescriptor,
+  policy: Policy,
+  options: ProjectUIIRDeonticOptions = {},
+): UIIRORBBridgeProjection {
+  const engine = options.engine ?? new PolicyEngine();
+  const projection = projectDeonticInterface(descriptor, policy, options.context, engine);
+  const actions: UIIRActionBinding[] = projection.methods.map(method => {
+    const presentation = presentationStateFromDeontic(method.state, method.reasons);
+    return {
+      action_id: options.action_ids?.[method.method]
+        ?? `action:${projection.interface_cid}:${method.method}`,
+      method: method.method,
+      interface_cid: projection.interface_cid,
+      ui_ir_cid: options.ui_ir_cid,
+      component_id: options.component_ids?.[method.method],
+      program_binding_id: options.program_binding_ids?.[method.method],
+      mcp_idl_binding_id: options.mcp_idl_binding_ids?.[method.method],
+      presentation,
+      deontic_state: method.state,
+      decision_cid: method.decision_cid,
+      capability: method.capability,
+      resource: method.resource,
+      reasons: method.reasons,
+      obligations: method.obligations,
+    };
+  });
+
+  return {
+    interface: UIIR_ORB_BRIDGE_INTERFACE,
+    ui_ir_cid: options.ui_ir_cid,
+    interface_cid: projection.interface_cid,
+    policy_cid: projection.policy_cid,
+    legacy_adapter: false,
+    actions,
+    policy_decisions: projection.policy_decisions,
+    projection,
+  };
+}
+
+/**
+ * Explicit adapter: existing non-UIIR MCP-IDL / UI-profile descriptors remain
+ * compatible by projecting through the same bridge surface without a ui_ir_cid.
+ * This is the sole supported path for legacy descriptors into UIIR-aware
+ * mediation; callers must not invent a parallel authorization shortcut.
+ */
+export function adaptNonUIIRDescriptorToORBBridge(
+  descriptor: InterfaceDescriptor,
+  policy: Policy,
+  options: Omit<ProjectUIIRDeonticOptions, 'ui_ir_cid'> = {},
+): UIIRORBBridgeProjection {
+  const bridged = projectUIIRDeonticInterface(descriptor, policy, options);
+  return {
+    ...bridged,
+    ui_ir_cid: undefined,
+    legacy_adapter: true,
+  };
+}
+
+/**
+ * Resolve a single action binding from a bridge projection. Missing actions
+ * fail closed (no synthetic permit).
+ */
+export function resolveUIIRActionBinding(
+  bridge: UIIRORBBridgeProjection,
+  method: string,
+): UIIRActionBinding | undefined {
+  return bridge.actions.find(action => action.method === method || action.action_id === method);
+}
+
+/**
+ * Build the identity bundle retained on mediation/invocation receipts.
+ * Presentation visibility is intentionally omitted.
+ */
+export function retainUIIRMediationIdentity(
+  partial: UIIRMediationIdentity,
+): UIIRMediationIdentity {
+  const retained: UIIRMediationIdentity = {};
+  if (partial.actor_id) retained.actor_id = partial.actor_id;
+  if (partial.delegation_chain?.length) {
+    retained.delegation_chain = [...partial.delegation_chain];
+  }
+  if (partial.ui_ir_cid) retained.ui_ir_cid = partial.ui_ir_cid;
+  if (partial.action_id) retained.action_id = partial.action_id;
+  if (partial.component_id) retained.component_id = partial.component_id;
+  if (partial.interface_cid) retained.interface_cid = partial.interface_cid;
+  if (partial.policy_cid) retained.policy_cid = partial.policy_cid;
+  if (partial.state_id) retained.state_id = partial.state_id;
+  if (partial.decision_id) retained.decision_id = partial.decision_id;
+  if (partial.decision_cid) retained.decision_cid = partial.decision_cid;
+  if (partial.invocation_id) retained.invocation_id = partial.invocation_id;
+  if (partial.correlation_id) retained.correlation_id = partial.correlation_id;
+  if (partial.program_binding_id) retained.program_binding_id = partial.program_binding_id;
+  if (partial.mcp_idl_binding_id) retained.mcp_idl_binding_id = partial.mcp_idl_binding_id;
+  return retained;
+}
+
+// ---------------------------------------------------------------------------
 // Top-level orchestration: formal logic -> constrained, multi-device UI
 // ---------------------------------------------------------------------------
 

--- a/src/services/mcp/mcp-orb-capability-router.ts
+++ b/src/services/mcp/mcp-orb-capability-router.ts
@@ -5,6 +5,8 @@ import {
   type ControlSurfaceMediationResult,
   type ControlSurfaceMediationReceipt,
   type ControlSurfaceInteractionEnvelope,
+  type ControlSurfaceRetainedIdentities,
+  type ControlSurfaceUIIRIdentity,
 } from './mcp-control-surface-mediator.js';
 import type { InterfaceDescriptor, MethodSignature } from './mcp-idl.js';
 import { computeCID } from './mcp-idl.js';
@@ -71,10 +73,25 @@ export interface ORBInvocationContext {
   correlation_id?: string;
   caller_did?: string;
   capabilities?: string[];
+  /** Formal-logic / deontic policy identity. Mandatory under UIIR mediation. */
   policy_cid?: string;
   parent_receipt_cids?: string[];
   control_surface?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
+  /** Runtime state identity retained on receipts. */
+  state_id?: string;
+  /**
+   * Real bounded input for streaming authorization. Prefer `stream(handle, input, context)`;
+   * this field remains for callers that only have a context bag.
+   */
+  input?: unknown;
+  /** UIIR identity bundle — engages strict policy/input mediation (UIR-033). */
+  uiir?: ControlSurfaceUIIRIdentity;
+  /**
+   * Force UIIR mediation gates even without ui_ir_cid (policy identity + real
+   * input mandatory; presentation never authorizes).
+   */
+  require_uiir_mediation?: boolean;
 }
 
 /**
@@ -102,6 +119,8 @@ export interface ORBPolicyDecision {
   mediated_input?: unknown;
   /** Obligations spawned by a deontic (Profile-D) policy for this invocation. */
   obligations?: ORBObligation[];
+  /** Actor/delegation/UI/action/IDL/policy/state/decision/invocation IDs. */
+  retained_identities?: ControlSurfaceRetainedIdentities;
 }
 
 /** Result of a deontic policy evaluation, as consumed by the ORB. */
@@ -294,6 +313,10 @@ export interface ORBInvocationReceipt {
   parent_receipt_cids: string[];
   lifecycle: ORBLifecycleRecord[];
   issued_at: string;
+  /** End-to-end retained identities (presentation excluded — never authorizes). */
+  retained_identities?: ControlSurfaceRetainedIdentities;
+  /** True when transport was skipped because a correlated duplicate already executed. */
+  correlated_dedup?: boolean;
 }
 
 export interface ORBInvocationRequest {
@@ -312,6 +335,13 @@ export interface ORBStreamSubscription {
   correlation_id: string;
   receipt: ORBInvocationReceipt;
   events: AsyncIterable<ORBStreamEvent>;
+}
+
+export interface ORBStreamInvocationRequest {
+  handle: string;
+  /** Current real stream input — mandatory under UIIR mediation. */
+  input?: unknown;
+  context?: ORBInvocationContext;
 }
 
 export interface MCPCapabilityRouterOptions {
@@ -487,6 +517,11 @@ export class MCPCapabilityRouter {
   private readonly rateLimitState = new Map<string, { count: number; window_start: number }>();
   private readonly circuitBreakerState = new Map<string, { failures: number; open_until: number }>();
   private readonly idempotencyCache = new Map<string, ORBTransportInvocationResult>();
+  /**
+   * Correlated-input transport cache: same correlation_id + input + operation
+   * reaches transport at most once. Policy is still re-evaluated every call.
+   */
+  private readonly correlatedInvocationCache = new Map<string, ORBTransportInvocationResult>();
 
   constructor(options: MCPCapabilityRouterOptions = {}) {
     this.registry = options.registry;
@@ -633,11 +668,22 @@ export class MCPCapabilityRouter {
     context: ORBInvocationContext = {},
   ): Promise<ORBPolicyDecision> {
     const binding = this.requireBinding(handle);
+    // Every authorization re-evaluates current policy with the current real input.
+    // Presentation state is never consulted as a grant.
     const mediation = await control_surface_mediator({
       binding,
       input,
-      context,
+      context: {
+        correlation_id: context.correlation_id,
+        caller_did: context.caller_did,
+        metadata: context.metadata,
+        control_surface: context.control_surface,
+        policy_cid: context.policy_cid,
+        state_id: context.state_id,
+        uiir: context.uiir,
+      },
       policy_evaluator: this.controlSurfacePolicyEvaluator,
+      require_uiir_mediation: context.require_uiir_mediation || Boolean(context.uiir?.ui_ir_cid || context.uiir?.action_id),
     });
     const mediatedContext = {
       ...context,
@@ -645,6 +691,7 @@ export class MCPCapabilityRouter {
         ...context.metadata,
         mediation_receipt_id: mediation.mediation_receipt.receipt_id,
         control_surface_contract_ref: mediation.control_surface_contract_ref,
+        retained_identities: mediation.retained_identities,
       },
     };
     const decision = mediation.can_invoke
@@ -658,9 +705,10 @@ export class MCPCapabilityRouter {
         reasons: mediation.policy_decision.reasons,
         required_capabilities: [],
         granted_capabilities: context.capabilities ?? [],
+        retained_identities: mediation.retained_identities,
       });
     const mediatedDecision = attachControlSurfaceMediation(decision, mediation);
-    const finalDecision = await this.applyDeonticPolicy(mediatedDecision, binding, mediatedContext);
+    const finalDecision = await this.applyDeonticPolicy(mediatedDecision, binding, mediatedContext, input);
     binding.lifecycle.push(lifecycle(
       'authorize',
       finalDecision.outcome === 'permit' ? 'ok' : 'denied',
@@ -673,22 +721,47 @@ export class MCPCapabilityRouter {
    * Layer a formal-logic (deontic Profile-D) evaluation on top of an already
    * control-surface-mediated + capability-checked decision.
    *
-   * No-op unless a `deontic_evaluator` was configured and the context carries a
-   * `policy_cid`. A deontic DENY flips the outcome to deny (reasons merged);
-   * a PERMIT / OBLIGATION_SPAWNED attaches any spawned obligations so the
-   * receipt and caller can track them. Never overrides an existing deny.
+   * Under UIIR mediation, missing policy identity fails closed. Otherwise this
+   * is a no-op unless a `deontic_evaluator` was configured and the context
+   * carries a `policy_cid`. A deontic DENY flips the outcome to deny; a PERMIT
+   * / OBLIGATION_SPAWNED attaches obligations. Never overrides an existing deny.
+   * Re-evaluates on every call with the current policy identity.
    */
   private async applyDeonticPolicy(
     decision: ORBPolicyDecision,
     binding: ORBBoundOperation,
     context: ORBInvocationContext,
+    _input: unknown,
   ): Promise<ORBPolicyDecision> {
-    if (!this.deonticEvaluator || !context.policy_cid || decision.outcome === 'deny') {
+    const uiirActive = Boolean(
+      context.require_uiir_mediation
+      || context.uiir?.ui_ir_cid
+      || context.uiir?.action_id,
+    );
+
+    if (decision.outcome === 'deny') {
+      return decision;
+    }
+
+    if (uiirActive && !context.policy_cid) {
+      const { decision_cid: _cid, ...rest } = decision;
+      return createPolicyDecision({
+        ...rest,
+        outcome: 'deny',
+        reasons: uniqueStrings([
+          ...decision.reasons,
+          'UIIR mediation requires policy identity (policy_cid) for unary and streaming authorization.',
+        ]),
+      });
+    }
+
+    if (!this.deonticEvaluator || !context.policy_cid) {
       return decision;
     }
     const timestamp = typeof context.metadata?.timestamp === 'string'
       ? context.metadata.timestamp
       : undefined;
+    // Always re-evaluate the current policy — never reuse a prior deontic decision.
     const evaluation = await this.deonticEvaluator.evaluate({
       policy_cid: context.policy_cid,
       capability: this.deonticInvokeCapability(binding.operation.method),
@@ -702,6 +775,11 @@ export class MCPCapabilityRouter {
         ...rest,
         outcome: 'deny',
         reasons: uniqueStrings([...decision.reasons, ...evaluation.reasons]),
+        retained_identities: {
+          ...rest.retained_identities,
+          decision_cid: evaluation.decision_cid,
+          policy_cid: context.policy_cid,
+        },
       });
     }
     return createPolicyDecision({
@@ -710,12 +788,18 @@ export class MCPCapabilityRouter {
         ? uniqueStrings([...decision.reasons, ...evaluation.obligations.map(o => `Obligation: ${o.description}`)])
         : decision.reasons,
       obligations: evaluation.obligations.length > 0 ? evaluation.obligations : rest.obligations,
+      retained_identities: {
+        ...rest.retained_identities,
+        decision_cid: evaluation.decision_cid,
+        policy_cid: context.policy_cid,
+      },
     });
   }
 
   async invoke(request: ORBInvocationRequest): Promise<ORBInvocationResponse> {
     const binding = this.requireBinding(request.handle);
     const context = withCorrelationId(request.context);
+    // Re-evaluate current policy with the current real input on every invocation.
     const policyDecision = await this.authorize(binding.handle, request.input, context);
     const invocationInput = policyDecision.mediated_input ?? request.input;
 
@@ -729,6 +813,30 @@ export class MCPCapabilityRouter {
     }
 
     const adapter = this.getAdapter(binding.transport);
+    const correlationKey = this.correlatedInvocationKey(binding, invocationInput, context);
+    const correlatedCached = correlationKey
+      ? this.correlatedInvocationCache.get(correlationKey)
+      : undefined;
+    if (correlatedCached) {
+      // Policy was re-evaluated above; transport is not called again for the
+      // same correlation_id + input (duplicate correlated inputs call at most once).
+      binding.lifecycle.push(lifecycle('invoke', 'ok', 'correlated input dedup'));
+      const receipt = buildORBReceipt(
+        binding,
+        correlatedCached.output,
+        policyDecision,
+        context,
+        correlatedCached.output_refs ?? collectOutputRefs(correlatedCached.output),
+        correlatedCached.provenance_refs ?? collectProvenanceRefs(correlatedCached.output),
+        { correlated_dedup: true },
+      );
+      return {
+        output: correlatedCached.output,
+        receipt,
+        denied: false,
+      };
+    }
+
     const cached = this.getCachedIdempotentResult(binding, invocationInput, context);
     if (cached) {
       binding.lifecycle.push(lifecycle('invoke', 'ok', 'idempotency cache hit'));
@@ -752,6 +860,9 @@ export class MCPCapabilityRouter {
       binding.lifecycle.push(lifecycle('invoke', 'ok'));
       this.recordCircuitBreakerSuccess(binding);
       this.storeIdempotentResult(binding, invocationInput, context, result);
+      if (correlationKey) {
+        this.correlatedInvocationCache.set(correlationKey, result);
+      }
       const outputRefs = result.output_refs ?? collectOutputRefs(result.output);
       const provenanceRefs = result.provenance_refs ?? collectProvenanceRefs(result.output);
       const receipt = buildORBReceipt(binding, result.output, policyDecision, context, outputRefs, provenanceRefs);
@@ -767,10 +878,30 @@ export class MCPCapabilityRouter {
     }
   }
 
-  async stream(handle: string, context: ORBInvocationContext = {}): Promise<ORBStreamSubscription> {
-    const binding = this.requireBinding(handle);
-    const streamContext = withCorrelationId(context);
-    const policyDecision = await this.authorize(binding.handle, {}, streamContext);
+  /**
+   * Stream with optional real input for authorization.
+   *
+   * Overloads:
+   * - `stream(handle, context)` — legacy non-UIIR path (empty stream input)
+   * - `stream(handle, input, context)` — preferred; real input for policy re-eval
+   * - `stream({ handle, input, context })` — explicit request form
+   *
+   * Under UIIR mediation, missing real input and missing policy identity fail
+   * closed and never open the transport stream.
+   */
+  async stream(
+    handleOrRequest: string | ORBStreamInvocationRequest,
+    inputOrContext: unknown = {},
+    maybeContext?: ORBInvocationContext,
+  ): Promise<ORBStreamSubscription> {
+    const resolved = resolveStreamInvocationArgs(handleOrRequest, inputOrContext, maybeContext);
+    const binding = this.requireBinding(resolved.handle);
+    const streamContext = withCorrelationId(resolved.context);
+    const streamInput = resolved.input;
+
+    // Always authorize with the current real input (not a synthetic empty object
+    // when the caller supplied stream payload).
+    const policyDecision = await this.authorize(binding.handle, streamInput, streamContext);
     if (policyDecision.outcome === 'deny') {
       binding.lifecycle.push(lifecycle('stream', 'denied', policyDecision.reasons.join('; ') || undefined));
       const receipt = buildORBReceipt(binding, { error: 'ORB_STREAM_DENIED' }, policyDecision, streamContext, [], []);
@@ -800,6 +931,23 @@ export class MCPCapabilityRouter {
       receipt,
       events,
     };
+  }
+
+  private correlatedInvocationKey(
+    binding: ORBBoundOperation,
+    input: unknown,
+    context: ORBInvocationContext,
+  ): string | undefined {
+    if (!context.correlation_id) {
+      return undefined;
+    }
+    return [
+      context.correlation_id,
+      binding.interface_cid,
+      binding.service.id,
+      binding.operation.method,
+      computeCID(stableStringify(input ?? null)),
+    ].join(':');
   }
 
   async recover(handle: string, context: ORBInvocationContext = {}, reason?: string): Promise<ORBRecoveryResult> {
@@ -1096,8 +1244,24 @@ export function buildORBReceipt(
   context: ORBInvocationContext,
   outputRefs: string[],
   provenanceRefs: string[],
+  options: { correlated_dedup?: boolean } = {},
 ): ORBInvocationReceipt {
   const outputCid = computeCID(stableStringify(output));
+  const retainedIdentities: ControlSurfaceRetainedIdentities = {
+    ...policyDecision.retained_identities,
+    interface_cid: policyDecision.retained_identities?.interface_cid ?? binding.interface_cid,
+    correlation_id: policyDecision.retained_identities?.correlation_id ?? context.correlation_id,
+    policy_cid: policyDecision.retained_identities?.policy_cid ?? context.policy_cid,
+    state_id: policyDecision.retained_identities?.state_id ?? context.state_id,
+    ui_ir_cid: policyDecision.retained_identities?.ui_ir_cid ?? context.uiir?.ui_ir_cid,
+    action_id: policyDecision.retained_identities?.action_id ?? context.uiir?.action_id,
+    invocation_id: policyDecision.retained_identities?.invocation_id
+      ?? context.correlation_id
+      ?? policyDecision.decision_cid,
+    decision_id: policyDecision.retained_identities?.decision_id
+      ?? policyDecision.mediation_receipt?.policy_decision.decision_id,
+    decision_cid: policyDecision.retained_identities?.decision_cid ?? policyDecision.decision_cid,
+  };
   const receiptWithoutCid = {
     correlation_id: context.correlation_id ?? newORBId(),
     interface_cid: binding.interface_cid,
@@ -1116,6 +1280,8 @@ export function buildORBReceipt(
     parent_receipt_cids: context.parent_receipt_cids ?? [],
     lifecycle: binding.lifecycle.slice(),
     issued_at: new Date().toISOString(),
+    retained_identities: retainedIdentities,
+    correlated_dedup: options.correlated_dedup === true ? true : undefined,
   };
 
   return {
@@ -1170,7 +1336,67 @@ function attachControlSurfaceMediation(
     interaction_envelope: mediation.interaction_envelope,
     mediation_receipt: mediation.mediation_receipt,
     mediated_input: mediation.invocation_input,
+    retained_identities: {
+      ...mediation.retained_identities,
+      ...decisionWithoutCid.retained_identities,
+      decision_id: mediation.policy_decision.decision_id,
+      interaction_id: mediation.interaction_envelope.interaction_id,
+    },
   });
+}
+
+function resolveStreamInvocationArgs(
+  handleOrRequest: string | ORBStreamInvocationRequest,
+  inputOrContext: unknown,
+  maybeContext?: ORBInvocationContext,
+): { handle: string; input: unknown; context: ORBInvocationContext } {
+  if (typeof handleOrRequest === 'object' && handleOrRequest !== null) {
+    const request = handleOrRequest;
+    const context = request.context ?? {};
+    const input = request.input !== undefined
+      ? request.input
+      : (context.input !== undefined ? context.input : {});
+    return { handle: request.handle, input, context };
+  }
+
+  const handle = handleOrRequest;
+  if (maybeContext !== undefined) {
+    // stream(handle, input, context)
+    return { handle, input: inputOrContext, context: maybeContext };
+  }
+
+  // stream(handle, context?) — legacy form used by existing non-UIIR callers.
+  // If the second arg looks like an ORB context, treat it as context with
+  // empty/default stream input (or context.input when provided).
+  if (isORBInvocationContextLike(inputOrContext)) {
+    const context = inputOrContext as ORBInvocationContext;
+    const input = context.input !== undefined ? context.input : {};
+    return { handle, input, context };
+  }
+
+  // stream(handle, input) with no context bag
+  return {
+    handle,
+    input: inputOrContext,
+    context: {},
+  };
+}
+
+function isORBInvocationContextLike(value: unknown): value is ORBInvocationContext {
+  if (!isRecord(value)) {
+    return false;
+  }
+  // Prefer context detection when known context keys are present.
+  return 'correlation_id' in value
+    || 'capabilities' in value
+    || 'control_surface' in value
+    || 'policy_cid' in value
+    || 'caller_did' in value
+    || 'parent_receipt_cids' in value
+    || 'uiir' in value
+    || 'require_uiir_mediation' in value
+    || 'state_id' in value
+    || 'metadata' in value;
 }
 
 function normalizeTransport(transport: MCPUIServiceDescriptor['transport']): ORBTransportKind {

--- a/src/services/mcp/ui-ux-ir-codec.ts
+++ b/src/services/mcp/ui-ux-ir-codec.ts
@@ -1,0 +1,2518 @@
+/**
+ * SwissKnife TypeScript UI/UX IR codec (UIR-032 / UIIRTypeScriptCodec@1).
+ *
+ * Exact-version decoding, closed field validation, set/ordered collection
+ * semantics, and canonical bytes aligned with the Python authority in
+ * `ipfs_datasets_py.logic.ui_ux_ir` (schema / decoder / canonicalize).
+ *
+ * This module does **not** invent TypeScript-only canonical fields. Wire
+ * identity is produced only from the closed `ui-ux-ir/v1` envelope.
+ */
+
+import { sha256Hex, utf8Bytes } from '../shared/shared-browser-crypto.js';
+import {
+  SWISSKNIFE_MCP_UI_PROFILE,
+  type MCPUIProfileDescriptor,
+  type MCPUISection,
+  type MCPUITemplateMapping,
+} from './mcp-ui-profile.js';
+
+// ---------------------------------------------------------------------------
+// Schema constants (mirror Python schema.py)
+// ---------------------------------------------------------------------------
+
+export const UI_UX_IR_SCHEMA_VERSION = 'ui-ux-ir/v1' as const;
+export const LEGACY_UI_UX_IR_SCHEMA_VERSION = 'ui-ux-ir/v0.1' as const;
+export const UI_UX_IR_INTERFACE = 'UIUXIR@1' as const;
+
+/** Closed top-level wire keys for ui-ux-ir/v1. */
+export const UIIR_DOCUMENT_FIELDS = Object.freeze([
+  'schema_version',
+  'document_id',
+  'title',
+  'locale_defaults',
+  'tags',
+  'sources',
+  'producer',
+  'configuration',
+  'review',
+  'trust_bindings',
+  'components',
+  'composition_edges',
+  'layout_regions',
+  'layout_constraints',
+  'design_token_refs',
+  'state_variables',
+  'states',
+  'events',
+  'transitions',
+  'guards',
+  'effects',
+  'ux_tasks',
+  'journeys',
+  'success_failure_recovery',
+  'feedback_contracts',
+  'accessibility',
+  'localization',
+  'input_modality_requirements',
+  'output_modality_requirements',
+  'modality_alternatives',
+  'device_capability_requirements',
+  'adaptive_variants',
+  'data_bindings',
+  'content_references',
+  'program_bindings',
+  'intent_ir_bindings',
+  'invocation_bindings',
+  'mcp_idl_bindings',
+  'formal_constraint_refs',
+  'proof_obligation_refs',
+  'entry_components',
+  'initial_states',
+  'terminal_outcomes',
+  'extensions',
+] as const);
+
+export const UIIR_REQUIRED_PATHS = Object.freeze([
+  'schema_version',
+  'document_id',
+  'title',
+  'sources',
+  'components',
+  'entry_components',
+  'terminal_outcomes',
+] as const);
+
+const UIIR_DOCUMENT_FIELD_SET = new Set<string>(UIIR_DOCUMENT_FIELDS);
+const UIIR_REQUIRED_PATH_SET = new Set<string>(UIIR_REQUIRED_PATHS);
+
+const IDENTIFIER_RE = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$/;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const NAMESPACE_RE =
+  /^[A-Za-z][A-Za-z0-9_-]{0,63}(\.[A-Za-z][A-Za-z0-9_-]{0,63}){0,7}$/;
+const VERSION_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
+
+const FORBIDDEN_EXECUTABLE_KEYS = new Set([
+  'callback',
+  'callbacks',
+  'code',
+  'eval',
+  'exec',
+  'executable',
+  'fn',
+  'function',
+  'handler',
+  'handlers',
+  'javascript',
+  'jsx',
+  'lambda',
+  'listener',
+  'listeners',
+  'on_blur',
+  'on_change',
+  'on_click',
+  'on_focus',
+  'on_input',
+  'on_submit',
+  'onchange',
+  'onclick',
+  'onsubmit',
+  'script',
+  'scripts',
+  'tsx',
+]);
+
+const FORBIDDEN_EXECUTABLE_KEY_PREFIXES = ['on_', 'handle_'] as const;
+
+export const ReviewStatus = {
+  UNREVIEWED: 'unreviewed',
+  MACHINE_EXTRACTED: 'machine_extracted',
+  HUMAN_REVIEWED: 'human_reviewed',
+  TRUSTED_FIXTURE: 'trusted_fixture',
+  QUARANTINED: 'quarantined',
+} as const;
+export type ReviewStatus = (typeof ReviewStatus)[keyof typeof ReviewStatus];
+
+export const TerminalOutcomeKind = {
+  SUCCESS: 'success',
+  FAILURE: 'failure',
+  PARTIAL: 'partial',
+  UNAVAILABLE: 'unavailable',
+  DEGRADED: 'degraded',
+} as const;
+export type TerminalOutcomeKind =
+  (typeof TerminalOutcomeKind)[keyof typeof TerminalOutcomeKind];
+
+export const ProgramBindingTargetKind = {
+  MCP_IDL: 'mcp_idl_interface_method_schema',
+  INTENT_IR: 'intent_ir_document_action',
+  INVOCATION_TEMPLATE: 'invocation_intent_template',
+  LOCAL_STATE: 'local_state_only_transition',
+  COMPOSITE_WORKFLOW: 'versioned_composite_workflow',
+} as const;
+export type ProgramBindingTargetKind =
+  (typeof ProgramBindingTargetKind)[keyof typeof ProgramBindingTargetKind];
+
+export const LayoutRegionKind = {
+  FLOW: 'flow',
+  GRID: 'grid',
+  STACK: 'stack',
+  OVERLAY: 'overlay',
+  SPATIAL_ANCHOR: 'spatial_anchor',
+  AUDIO_SEQUENCE: 'audio_sequence',
+} as const;
+export type LayoutRegionKind =
+  (typeof LayoutRegionKind)[keyof typeof LayoutRegionKind];
+
+export const AuthorityKind = {
+  DECLARATION: 'declaration',
+  INTERFACE: 'interface',
+  LEGACY_ALIAS: 'legacy_alias',
+  PROJECTION: 'projection',
+  OBSERVATION: 'observation',
+  MEDIATION: 'mediation',
+  INVOCATION: 'invocation',
+  SATISFIABILITY: 'satisfiability',
+  MONITOR: 'monitor',
+  PROOF: 'proof',
+  ACCESSIBILITY: 'accessibility',
+  POLICY: 'policy',
+  SYNTHESIS_CANDIDATE: 'synthesis_candidate',
+  CONFORMANCE: 'conformance',
+} as const;
+export type AuthorityKind = (typeof AuthorityKind)[keyof typeof AuthorityKind];
+
+// ---------------------------------------------------------------------------
+// Error classes (mirror Python UIIRValidationError / UIIRDecodeError)
+// ---------------------------------------------------------------------------
+
+export class UIIRValidationError extends Error {
+  readonly name = 'UIIRValidationError';
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class UIIRDecodeError extends UIIRValidationError {
+  readonly name = 'UIIRDecodeError';
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Wire record types (JSON-ready; match Python *.to_dict() shapes)
+// ---------------------------------------------------------------------------
+
+export interface SourceSpan {
+  start_char: number;
+  end_char: number;
+}
+
+export interface UISourceRef {
+  ref_id: string;
+  source_uri: string;
+  source_id: string;
+  source_revision: string;
+  content_sha256: string;
+  container_uri?: string;
+  container_sha256?: string;
+  content_cid?: string;
+  license_expression?: string;
+  review_status?: ReviewStatus | string;
+  span?: SourceSpan | null;
+}
+
+export interface UILocaleDefaults {
+  default_locale: string;
+  fallback_locales: string[];
+  text_direction: string;
+}
+
+export interface UIProducer {
+  producer_id: string;
+  name: string;
+  version?: string;
+}
+
+export interface UIConfiguration {
+  configuration_id: string;
+  profile?: string;
+  settings?: Record<string, unknown>;
+}
+
+export interface UIReviewBinding {
+  review_status: ReviewStatus | string;
+  reviewer?: string;
+  notes?: string;
+}
+
+export interface UITrustBinding {
+  trust_id: string;
+  authority_kind: AuthorityKind | string;
+  subject_ref: string;
+  source_ref_ids?: string[];
+}
+
+export interface UIComponent {
+  component_id: string;
+  role: string;
+  purpose?: string;
+  accessible_name_ref?: string;
+  accessible_description_ref?: string;
+  parent_id?: string;
+  child_ids?: string[];
+  modality_binding_ids?: string[];
+  data_binding_ids?: string[];
+  program_binding_ids?: string[];
+  feedback_ids?: string[];
+  privacy_sensitivity?: string;
+  presentation_classification?: string;
+  source_ref_ids?: string[];
+}
+
+export interface UILayoutRegion {
+  region_id: string;
+  kind: LayoutRegionKind | string;
+  component_ids?: string[];
+  source_ref_ids?: string[];
+}
+
+export interface UIProgramBinding {
+  binding_id: string;
+  target_kind: ProgramBindingTargetKind | string;
+  target_ref: string;
+  risk_class?: string;
+  confirmation_class?: string;
+  precondition_ids?: string[];
+  effect_ids?: string[];
+  verification_ids?: string[];
+  source_ref_ids?: string[];
+}
+
+export interface UIMCPIDLBinding {
+  binding_id: string;
+  interface_cid: string;
+  method_name: string;
+  argument_schema_ref?: string;
+  result_schema_ref?: string;
+  source_ref_ids?: string[];
+}
+
+export interface UIFeedbackContract {
+  feedback_id: string;
+  channel: string;
+  component_id?: string;
+  source_ref_ids?: string[];
+}
+
+export interface UITerminalOutcome {
+  outcome_id: string;
+  kind: TerminalOutcomeKind | string;
+  description?: string;
+  source_ref_ids?: string[];
+}
+
+export interface UIStateVariable {
+  variable_id: string;
+  value_type: string;
+  derived?: boolean;
+  source_ref_ids?: string[];
+}
+
+export interface UIEvent {
+  event_id: string;
+  kind: string;
+  source_ref_ids?: string[];
+}
+
+export interface UIUXTask {
+  task_id: string;
+  name: string;
+  step_component_ids?: string[];
+  source_ref_ids?: string[];
+}
+
+export interface UIJourney {
+  journey_id: string;
+  name: string;
+  task_ids?: string[];
+  source_ref_ids?: string[];
+}
+
+export interface UINamespacedExtension {
+  extension_id: string;
+  namespace: string;
+  version: string;
+  payload?: Record<string, unknown>;
+  required?: boolean;
+  source_ref_ids?: string[];
+}
+
+/**
+ * Closed ui-ux-ir/v1 document envelope (JSON-ready).
+ * Optional collections default to empty when omitted from input; toDict always
+ * emits the full closed field set so canonical bytes match Python.
+ */
+export interface UIIRDocument {
+  schema_version: string;
+  document_id: string;
+  title: string;
+  sources: UISourceRef[];
+  components: UIComponent[];
+  entry_components: string[];
+  terminal_outcomes: UITerminalOutcome[];
+  locale_defaults?: UILocaleDefaults;
+  tags?: string[];
+  producer?: UIProducer | null;
+  configuration?: UIConfiguration | null;
+  review?: UIReviewBinding;
+  trust_bindings?: UITrustBinding[];
+  composition_edges?: unknown[];
+  layout_regions?: UILayoutRegion[];
+  layout_constraints?: unknown[];
+  design_token_refs?: unknown[];
+  state_variables?: UIStateVariable[];
+  states?: unknown[];
+  events?: UIEvent[];
+  transitions?: unknown[];
+  guards?: unknown[];
+  effects?: unknown[];
+  ux_tasks?: UIUXTask[];
+  journeys?: UIJourney[];
+  success_failure_recovery?: unknown[];
+  feedback_contracts?: UIFeedbackContract[];
+  accessibility?: unknown[];
+  localization?: unknown[];
+  input_modality_requirements?: unknown[];
+  output_modality_requirements?: unknown[];
+  modality_alternatives?: unknown[];
+  device_capability_requirements?: unknown[];
+  adaptive_variants?: unknown[];
+  data_bindings?: unknown[];
+  content_references?: unknown[];
+  program_bindings?: UIProgramBinding[];
+  intent_ir_bindings?: unknown[];
+  invocation_bindings?: unknown[];
+  mcp_idl_bindings?: UIMCPIDLBinding[];
+  formal_constraint_refs?: unknown[];
+  proof_obligation_refs?: unknown[];
+  initial_states?: string[];
+  extensions?: UINamespacedExtension[];
+}
+
+export interface UIIRConversionLoss {
+  path: string;
+  reason: string;
+  source_value?: unknown;
+}
+
+export interface UIIRProfileConversionResult {
+  document: UIIRDocument;
+  losses: UIIRConversionLoss[];
+  lossy: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isForbiddenExecutableKey(key: string): boolean {
+  const lowered = key.toLowerCase();
+  if (FORBIDDEN_EXECUTABLE_KEYS.has(lowered)) return true;
+  return FORBIDDEN_EXECUTABLE_KEY_PREFIXES.some(prefix =>
+    lowered.startsWith(prefix),
+  );
+}
+
+function rejectExecutablePayload(
+  value: unknown,
+  label: string,
+  path = '',
+): void {
+  if (typeof value === 'function') {
+    throw new UIIRValidationError(
+      `${label}${path} contains an executable callback`,
+    );
+  }
+  if (isPlainObject(value)) {
+    for (const [key, item] of Object.entries(value)) {
+      if (isForbiddenExecutableKey(key)) {
+        throw new UIIRValidationError(
+          `${label}${path}/${key} is an executable callback field`,
+        );
+      }
+      rejectExecutablePayload(item, label, `${path}/${key}`);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      rejectExecutablePayload(item, label, `${path}[${index}]`),
+    );
+  }
+}
+
+function validateIdentifier(name: string, value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !IDENTIFIER_RE.test(value)) {
+    throw new UIIRValidationError(`${name} is not a stable identifier`);
+  }
+}
+
+function validateNonEmptyString(
+  name: string,
+  value: unknown,
+): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new UIIRValidationError(`${name} must be a string`);
+  }
+  if (!value.trim()) {
+    throw new UIIRValidationError(`${name} must not be empty`);
+  }
+}
+
+function validateString(name: string, value: unknown): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new UIIRValidationError(`${name} must be a string`);
+  }
+}
+
+function validateSha256(name: string, value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !SHA256_RE.test(value)) {
+    throw new UIIRValidationError(
+      `${name} must be a lowercase 64-character SHA-256`,
+    );
+  }
+}
+
+function requireUnique(values: Iterable<string>, label: string): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      throw new UIIRValidationError(`Duplicate ${label} id: ${value}`);
+    }
+    seen.add(value);
+  }
+}
+
+function requireKnownRefs(
+  values: Iterable<string>,
+  known: Set<string>,
+  label: string,
+): void {
+  const missing = [...new Set([...values].filter(v => !known.has(v)))].sort();
+  if (missing.length > 0) {
+    throw new UIIRValidationError(
+      `${label} references unknown ids: ${missing.join(', ')}`,
+    );
+  }
+}
+
+function sortedUniqueStrings(values: readonly string[] | undefined): string[] {
+  return [...new Set(values ?? [])].sort();
+}
+
+function asStringArray(value: unknown, label: string): string[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new UIIRDecodeError(`${label} must be an array`);
+  }
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item !== 'string' || !item.trim()) {
+      throw new UIIRDecodeError(`${label} members must be non-empty strings`);
+    }
+    out.push(item);
+  }
+  return out;
+}
+
+function requireObject(
+  value: unknown,
+  label: string,
+): Record<string, unknown> {
+  if (!isPlainObject(value)) {
+    throw new UIIRDecodeError(`${label} must be an object`);
+  }
+  return value;
+}
+
+function stableId(raw: string, fallbackPrefix: string): string {
+  const cleaned = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._:/-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (cleaned && IDENTIFIER_RE.test(cleaned)) return cleaned;
+  const digest = sha256Hex(raw).slice(0, 16);
+  return `${fallbackPrefix}:${digest}`;
+}
+
+// ---------------------------------------------------------------------------
+// Record normalization (mirror Python to_dict set/order semantics)
+// ---------------------------------------------------------------------------
+
+function normalizeSource(raw: UISourceRef): Record<string, unknown> {
+  return {
+    container_sha256: raw.container_sha256 ?? '',
+    container_uri: raw.container_uri ?? '',
+    content_cid: raw.content_cid ?? '',
+    content_sha256: raw.content_sha256,
+    license_expression: raw.license_expression ?? '',
+    ref_id: raw.ref_id,
+    review_status: raw.review_status ?? ReviewStatus.UNREVIEWED,
+    source_id: raw.source_id,
+    source_revision: raw.source_revision,
+    source_uri: raw.source_uri,
+    span: raw.span
+      ? {
+          end_char: raw.span.end_char,
+          start_char: raw.span.start_char,
+        }
+      : null,
+  };
+}
+
+function normalizeComponent(raw: UIComponent): Record<string, unknown> {
+  return {
+    accessible_description_ref: raw.accessible_description_ref ?? '',
+    accessible_name_ref: raw.accessible_name_ref ?? '',
+    child_ids: [...(raw.child_ids ?? [])],
+    component_id: raw.component_id,
+    data_binding_ids: sortedUniqueStrings(raw.data_binding_ids),
+    feedback_ids: sortedUniqueStrings(raw.feedback_ids),
+    modality_binding_ids: sortedUniqueStrings(raw.modality_binding_ids),
+    parent_id: raw.parent_id ?? '',
+    presentation_classification:
+      raw.presentation_classification ?? 'interactive',
+    privacy_sensitivity: raw.privacy_sensitivity ?? 'none',
+    program_binding_ids: sortedUniqueStrings(raw.program_binding_ids),
+    purpose: raw.purpose ?? '',
+    role: raw.role,
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+  };
+}
+
+function normalizeTerminal(raw: UITerminalOutcome): Record<string, unknown> {
+  return {
+    description: raw.description ?? '',
+    kind: raw.kind,
+    outcome_id: raw.outcome_id,
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+  };
+}
+
+function normalizeLocale(
+  raw: UILocaleDefaults | undefined,
+): Record<string, unknown> {
+  return {
+    default_locale: raw?.default_locale ?? 'en',
+    fallback_locales: [...(raw?.fallback_locales ?? [])],
+    text_direction: raw?.text_direction ?? 'ltr',
+  };
+}
+
+function normalizeReview(
+  raw: UIReviewBinding | undefined,
+): Record<string, unknown> {
+  return {
+    notes: raw?.notes ?? '',
+    review_status: raw?.review_status ?? ReviewStatus.UNREVIEWED,
+    reviewer: raw?.reviewer ?? '',
+  };
+}
+
+function normalizeProducer(
+  raw: UIProducer | null | undefined,
+): Record<string, unknown> | null {
+  if (!raw) return null;
+  return {
+    name: raw.name,
+    producer_id: raw.producer_id,
+    version: raw.version ?? '',
+  };
+}
+
+function normalizeConfiguration(
+  raw: UIConfiguration | null | undefined,
+): Record<string, unknown> | null {
+  if (!raw) return null;
+  return {
+    configuration_id: raw.configuration_id,
+    profile: raw.profile ?? 'default',
+    settings: { ...(raw.settings ?? {}) },
+  };
+}
+
+function normalizeProgramBinding(
+  raw: UIProgramBinding,
+): Record<string, unknown> {
+  return {
+    binding_id: raw.binding_id,
+    confirmation_class: raw.confirmation_class ?? 'none',
+    effect_ids: sortedUniqueStrings(raw.effect_ids),
+    precondition_ids: sortedUniqueStrings(raw.precondition_ids),
+    risk_class: raw.risk_class ?? 'low',
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+    target_kind: raw.target_kind,
+    target_ref: raw.target_ref,
+    verification_ids: sortedUniqueStrings(raw.verification_ids),
+  };
+}
+
+function normalizeMcpIdlBinding(
+  raw: UIMCPIDLBinding,
+): Record<string, unknown> {
+  return {
+    argument_schema_ref: raw.argument_schema_ref ?? '',
+    binding_id: raw.binding_id,
+    interface_cid: raw.interface_cid,
+    method_name: raw.method_name,
+    result_schema_ref: raw.result_schema_ref ?? '',
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+  };
+}
+
+function normalizeFeedback(raw: UIFeedbackContract): Record<string, unknown> {
+  return {
+    channel: raw.channel,
+    component_id: raw.component_id ?? '',
+    feedback_id: raw.feedback_id,
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+  };
+}
+
+function normalizeLayoutRegion(raw: UILayoutRegion): Record<string, unknown> {
+  return {
+    component_ids: [...(raw.component_ids ?? [])],
+    kind: raw.kind,
+    region_id: raw.region_id,
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+  };
+}
+
+function normalizeStateVariable(raw: UIStateVariable): Record<string, unknown> {
+  return {
+    derived: raw.derived ?? false,
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+    value_type: raw.value_type,
+    variable_id: raw.variable_id,
+  };
+}
+
+function normalizeEvent(raw: UIEvent): Record<string, unknown> {
+  return {
+    event_id: raw.event_id,
+    kind: raw.kind,
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+  };
+}
+
+function normalizeTask(raw: UIUXTask): Record<string, unknown> {
+  return {
+    name: raw.name,
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+    step_component_ids: [...(raw.step_component_ids ?? [])],
+    task_id: raw.task_id,
+  };
+}
+
+function normalizeJourney(raw: UIJourney): Record<string, unknown> {
+  return {
+    journey_id: raw.journey_id,
+    name: raw.name,
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+    task_ids: [...(raw.task_ids ?? [])],
+  };
+}
+
+function normalizeTrust(raw: UITrustBinding): Record<string, unknown> {
+  return {
+    authority_kind: raw.authority_kind,
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+    subject_ref: raw.subject_ref,
+    trust_id: raw.trust_id,
+  };
+}
+
+function normalizeExtension(
+  raw: UINamespacedExtension,
+): Record<string, unknown> {
+  return {
+    extension_id: raw.extension_id,
+    namespace: raw.namespace,
+    payload: { ...(raw.payload ?? {}) },
+    required: raw.required ?? false,
+    source_ref_ids: sortedUniqueStrings(raw.source_ref_ids),
+    version: raw.version,
+  };
+}
+
+function sortByKey<T>(
+  items: readonly T[] | undefined,
+  keyFn: (item: T) => string,
+): T[] {
+  return [...(items ?? [])].sort((a, b) =>
+    keyFn(a).localeCompare(keyFn(b), 'en'),
+  );
+}
+
+/**
+ * Emit the full closed envelope payload (Python UIIRDocument.to_dict parity).
+ * Never adds TypeScript-only fields.
+ */
+export function uiIrToDict(
+  document: UIIRDocument | Record<string, unknown>,
+): Record<string, unknown> {
+  const doc = document as UIIRDocument;
+  return {
+    accessibility: sortByKey(
+      (doc.accessibility as Array<{ accessibility_id?: string }> | undefined) ??
+        [],
+      item => String(item.accessibility_id ?? ''),
+    ),
+    adaptive_variants: sortByKey(
+      (doc.adaptive_variants as Array<{ variant_id?: string }> | undefined) ??
+        [],
+      item => String(item.variant_id ?? ''),
+    ),
+    components: sortByKey(doc.components ?? [], item => item.component_id).map(
+      normalizeComponent,
+    ),
+    composition_edges: sortByKey(
+      (doc.composition_edges as Array<{ edge_id?: string }> | undefined) ?? [],
+      item => String(item.edge_id ?? ''),
+    ),
+    configuration: normalizeConfiguration(doc.configuration),
+    content_references: sortByKey(
+      (doc.content_references as Array<{ content_id?: string }> | undefined) ??
+        [],
+      item => String(item.content_id ?? ''),
+    ),
+    data_bindings: sortByKey(
+      (doc.data_bindings as Array<{ binding_id?: string }> | undefined) ?? [],
+      item => String(item.binding_id ?? ''),
+    ),
+    design_token_refs: sortByKey(
+      (doc.design_token_refs as Array<{ token_id?: string }> | undefined) ?? [],
+      item => String(item.token_id ?? ''),
+    ),
+    device_capability_requirements: sortByKey(
+      (doc.device_capability_requirements as
+        | Array<{ requirement_id?: string }>
+        | undefined) ?? [],
+      item => String(item.requirement_id ?? ''),
+    ),
+    document_id: doc.document_id,
+    effects: sortByKey(
+      (doc.effects as Array<{ effect_id?: string }> | undefined) ?? [],
+      item => String(item.effect_id ?? ''),
+    ),
+    entry_components: sortedUniqueStrings(doc.entry_components),
+    events: sortByKey(doc.events ?? [], item => item.event_id).map(
+      normalizeEvent,
+    ),
+    extensions: sortByKey(doc.extensions ?? [], item => item.extension_id).map(
+      normalizeExtension,
+    ),
+    feedback_contracts: sortByKey(
+      doc.feedback_contracts ?? [],
+      item => item.feedback_id,
+    ).map(normalizeFeedback),
+    formal_constraint_refs: sortByKey(
+      (doc.formal_constraint_refs as
+        | Array<{ constraint_id?: string }>
+        | undefined) ?? [],
+      item => String(item.constraint_id ?? ''),
+    ),
+    guards: sortByKey(
+      (doc.guards as Array<{ guard_id?: string }> | undefined) ?? [],
+      item => String(item.guard_id ?? ''),
+    ),
+    initial_states: sortedUniqueStrings(doc.initial_states),
+    input_modality_requirements: sortByKey(
+      (doc.input_modality_requirements as
+        | Array<{ requirement_id?: string }>
+        | undefined) ?? [],
+      item => String(item.requirement_id ?? ''),
+    ),
+    intent_ir_bindings: sortByKey(
+      (doc.intent_ir_bindings as Array<{ binding_id?: string }> | undefined) ??
+        [],
+      item => String(item.binding_id ?? ''),
+    ),
+    invocation_bindings: sortByKey(
+      (doc.invocation_bindings as Array<{ binding_id?: string }> | undefined) ??
+        [],
+      item => String(item.binding_id ?? ''),
+    ),
+    journeys: sortByKey(doc.journeys ?? [], item => item.journey_id).map(
+      normalizeJourney,
+    ),
+    layout_constraints: sortByKey(
+      (doc.layout_constraints as Array<{ constraint_id?: string }> | undefined) ??
+        [],
+      item => String(item.constraint_id ?? ''),
+    ),
+    layout_regions: sortByKey(
+      doc.layout_regions ?? [],
+      item => item.region_id,
+    ).map(normalizeLayoutRegion),
+    locale_defaults: normalizeLocale(doc.locale_defaults),
+    localization: sortByKey(
+      (doc.localization as Array<{ localization_id?: string }> | undefined) ??
+        [],
+      item => String(item.localization_id ?? ''),
+    ),
+    mcp_idl_bindings: sortByKey(
+      doc.mcp_idl_bindings ?? [],
+      item => item.binding_id,
+    ).map(normalizeMcpIdlBinding),
+    modality_alternatives: sortByKey(
+      (doc.modality_alternatives as
+        | Array<{ alternative_id?: string }>
+        | undefined) ?? [],
+      item => String(item.alternative_id ?? ''),
+    ),
+    output_modality_requirements: sortByKey(
+      (doc.output_modality_requirements as
+        | Array<{ requirement_id?: string }>
+        | undefined) ?? [],
+      item => String(item.requirement_id ?? ''),
+    ),
+    producer: normalizeProducer(doc.producer),
+    program_bindings: sortByKey(
+      doc.program_bindings ?? [],
+      item => item.binding_id,
+    ).map(normalizeProgramBinding),
+    proof_obligation_refs: sortByKey(
+      (doc.proof_obligation_refs as
+        | Array<{ obligation_id?: string }>
+        | undefined) ?? [],
+      item => String(item.obligation_id ?? ''),
+    ),
+    review: normalizeReview(doc.review),
+    schema_version: doc.schema_version || UI_UX_IR_SCHEMA_VERSION,
+    sources: sortByKey(doc.sources ?? [], item => item.ref_id).map(
+      normalizeSource,
+    ),
+    state_variables: sortByKey(
+      doc.state_variables ?? [],
+      item => item.variable_id,
+    ).map(normalizeStateVariable),
+    states: sortByKey(
+      (doc.states as Array<{ state_id?: string }> | undefined) ?? [],
+      item => String(item.state_id ?? ''),
+    ),
+    success_failure_recovery: sortByKey(
+      (doc.success_failure_recovery as Array<{ path_id?: string }> | undefined) ??
+        [],
+      item => String(item.path_id ?? ''),
+    ),
+    tags: sortedUniqueStrings(doc.tags),
+    terminal_outcomes: sortByKey(
+      doc.terminal_outcomes ?? [],
+      item => item.outcome_id,
+    ).map(normalizeTerminal),
+    title: doc.title,
+    transitions: sortByKey(
+      (doc.transitions as Array<{ transition_id?: string }> | undefined) ?? [],
+      item => String(item.transition_id ?? ''),
+    ),
+    trust_bindings: sortByKey(
+      doc.trust_bindings ?? [],
+      item => item.trust_id,
+    ).map(normalizeTrust),
+    ux_tasks: sortByKey(doc.ux_tasks ?? [], item => item.task_id).map(
+      normalizeTask,
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Canonicalization (mirror Python canonicalize.py)
+// ---------------------------------------------------------------------------
+
+function normalizeCanonical(value: unknown): unknown {
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = normalizeCanonical(value[key]);
+    }
+    return out;
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => normalizeCanonical(item));
+  }
+  return value;
+}
+
+/**
+ * Ensure ASCII-only JSON text (Python json.dumps ensure_ascii=True parity).
+ */
+function ensureAsciiJson(text: string): string {
+  return text.replace(/[\u007f-\uffff]/g, ch => {
+    const code = ch.charCodeAt(0);
+    return `\\u${code.toString(16).padStart(4, '0')}`;
+  });
+}
+
+/**
+ * Return deterministic UTF-8 JSON bytes for a validated declaration.
+ * Canonical identity is independent of optional CID availability.
+ */
+export function canonicalizeUiIr(
+  document: UIIRDocument | Record<string, unknown>,
+): Uint8Array {
+  const payload = uiIrToDict(document);
+  const version = String(payload.schema_version ?? '');
+  if (version && version !== UI_UX_IR_SCHEMA_VERSION) {
+    throw new UIIRValidationError(
+      `Cannot canonicalize unsupported schema_version ${JSON.stringify(version)}; expected ${JSON.stringify(UI_UX_IR_SCHEMA_VERSION)}`,
+    );
+  }
+  const text = ensureAsciiJson(JSON.stringify(normalizeCanonical(payload)));
+  return utf8Bytes(text);
+}
+
+/** Alias matching Python/public API naming. */
+export const canonicalizeUIIR = canonicalizeUiIr;
+export const canonicalize_ui_ir = canonicalizeUiIr;
+
+/** Return `sha256:<hex>` for the canonical declaration bytes. */
+export function uiIrSha256(
+  document: UIIRDocument | Record<string, unknown>,
+): string {
+  return `sha256:${sha256Hex(canonicalizeUiIr(document))}`;
+}
+
+export const ui_ir_sha256 = uiIrSha256;
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export function rejectUnknownDocumentFields(
+  payload: Record<string, unknown>,
+): void {
+  if (!isPlainObject(payload)) {
+    throw new UIIRValidationError('document payload must be a mapping');
+  }
+  const unknown = Object.keys(payload)
+    .filter(key => !UIIR_DOCUMENT_FIELD_SET.has(key))
+    .sort();
+  if (unknown.length > 0) {
+    throw new UIIRValidationError(
+      `unknown UIIRDocument field(s): ${unknown.join(', ')}`,
+    );
+  }
+  const missing = [...UIIR_REQUIRED_PATH_SET]
+    .filter(name => !(name in payload))
+    .sort();
+  if (missing.length > 0) {
+    throw new UIIRValidationError(
+      `missing required UIIRDocument path(s): ${missing.join(', ')}`,
+    );
+  }
+}
+
+function validateSource(source: UISourceRef): void {
+  validateIdentifier('UISourceRef.ref_id', source.ref_id);
+  validateNonEmptyString('UISourceRef.source_uri', source.source_uri);
+  validateNonEmptyString('UISourceRef.source_id', source.source_id);
+  validateNonEmptyString('UISourceRef.source_revision', source.source_revision);
+  validateSha256('UISourceRef.content_sha256', source.content_sha256);
+  if (source.container_sha256) {
+    validateSha256('UISourceRef.container_sha256', source.container_sha256);
+  }
+  if (source.span) {
+    const { start_char, end_char } = source.span;
+    if (
+      !Number.isInteger(start_char) ||
+      !Number.isInteger(end_char) ||
+      start_char < 0 ||
+      end_char < start_char
+    ) {
+      throw new UIIRValidationError(
+        'SourceSpan must satisfy 0 <= start_char <= end_char',
+      );
+    }
+  }
+  rejectExecutablePayload(normalizeSource(source), 'UISourceRef');
+}
+
+function validateComponent(component: UIComponent): void {
+  validateIdentifier('UIComponent.component_id', component.component_id);
+  validateNonEmptyString('UIComponent.role', component.role);
+  if (component.parent_id) {
+    validateIdentifier('UIComponent.parent_id', component.parent_id);
+  }
+  for (const id of component.child_ids ?? []) {
+    validateIdentifier('UIComponent.child_ids', id);
+  }
+  for (const field of [
+    'modality_binding_ids',
+    'data_binding_ids',
+    'program_binding_ids',
+    'feedback_ids',
+    'source_ref_ids',
+  ] as const) {
+    const values = component[field] ?? [];
+    requireUnique(values, `UIComponent.${field} member`);
+    for (const id of values) {
+      validateIdentifier(`UIComponent.${field}`, id);
+    }
+  }
+  rejectExecutablePayload(
+    normalizeComponent(component),
+    `UIComponent ${component.component_id}`,
+  );
+}
+
+function validateTerminal(outcome: UITerminalOutcome): void {
+  validateIdentifier('UITerminalOutcome.outcome_id', outcome.outcome_id);
+  const kinds = new Set(Object.values(TerminalOutcomeKind));
+  if (!kinds.has(outcome.kind as TerminalOutcomeKind)) {
+    throw new UIIRValidationError(
+      `UITerminalOutcome.kind must be a TerminalOutcomeKind value`,
+    );
+  }
+  requireUnique(
+    outcome.source_ref_ids ?? [],
+    'UITerminalOutcome.source_ref_ids member',
+  );
+  for (const id of outcome.source_ref_ids ?? []) {
+    validateIdentifier('UITerminalOutcome.source_ref_ids', id);
+  }
+}
+
+function validateLocale(locale: UILocaleDefaults): void {
+  validateNonEmptyString(
+    'UILocaleDefaults.default_locale',
+    locale.default_locale,
+  );
+  for (const item of locale.fallback_locales) {
+    validateNonEmptyString('UILocaleDefaults.fallback_locales', item);
+  }
+  validateNonEmptyString(
+    'UILocaleDefaults.text_direction',
+    locale.text_direction,
+  );
+  if (!['ltr', 'rtl', 'auto'].includes(locale.text_direction)) {
+    throw new UIIRValidationError(
+      'UILocaleDefaults.text_direction must be ltr, rtl, or auto',
+    );
+  }
+}
+
+/**
+ * Validate a decoded document (cross-reference closure for mapped fields).
+ */
+export function validateUiIr(document: UIIRDocument): UIIRDocument {
+  if (document.schema_version !== UI_UX_IR_SCHEMA_VERSION) {
+    throw new UIIRValidationError(
+      `Unsupported UI/UX IR schema_version: ${JSON.stringify(document.schema_version)}`,
+    );
+  }
+  validateIdentifier('UIIRDocument.document_id', document.document_id);
+  validateNonEmptyString('UIIRDocument.title', document.title);
+
+  if (!document.sources?.length) {
+    throw new UIIRValidationError('UIIRDocument.sources must not be empty');
+  }
+  if (!document.components?.length) {
+    throw new UIIRValidationError('UIIRDocument.components must not be empty');
+  }
+  if (!document.entry_components?.length) {
+    throw new UIIRValidationError(
+      'UIIRDocument.entry_components must not be empty',
+    );
+  }
+  if (!document.terminal_outcomes?.length) {
+    throw new UIIRValidationError(
+      'UIIRDocument.terminal_outcomes must not be empty',
+    );
+  }
+
+  const locale = {
+    default_locale: document.locale_defaults?.default_locale ?? 'en',
+    fallback_locales: [...(document.locale_defaults?.fallback_locales ?? [])],
+    text_direction: document.locale_defaults?.text_direction ?? 'ltr',
+  };
+  validateLocale(locale);
+
+  for (const source of document.sources) validateSource(source);
+  for (const component of document.components) validateComponent(component);
+  for (const outcome of document.terminal_outcomes) validateTerminal(outcome);
+
+  requireUnique(
+    document.sources.map(s => s.ref_id),
+    'source ref',
+  );
+  requireUnique(
+    document.components.map(c => c.component_id),
+    'component',
+  );
+  requireUnique(
+    document.terminal_outcomes.map(o => o.outcome_id),
+    'terminal outcome',
+  );
+  requireUnique(document.entry_components, 'entry_components member');
+  requireUnique(document.tags ?? [], 'tags member');
+  requireUnique(document.initial_states ?? [], 'initial_states member');
+
+  if (document.program_bindings) {
+    requireUnique(
+      document.program_bindings.map(b => b.binding_id),
+      'program binding',
+    );
+  }
+  if (document.mcp_idl_bindings) {
+    requireUnique(
+      document.mcp_idl_bindings.map(b => b.binding_id),
+      'mcp idl binding',
+    );
+  }
+  if (document.feedback_contracts) {
+    requireUnique(
+      document.feedback_contracts.map(b => b.feedback_id),
+      'feedback',
+    );
+  }
+  if (document.layout_regions) {
+    requireUnique(
+      document.layout_regions.map(r => r.region_id),
+      'layout region',
+    );
+  }
+  if (document.extensions) {
+    requireUnique(
+      document.extensions.map(e => e.extension_id),
+      'extension',
+    );
+    for (const ext of document.extensions) {
+      validateIdentifier('UINamespacedExtension.extension_id', ext.extension_id);
+      if (typeof ext.namespace !== 'string' || !NAMESPACE_RE.test(ext.namespace)) {
+        throw new UIIRValidationError(
+          'UINamespacedExtension.namespace must be a dotted namespace',
+        );
+      }
+      if (typeof ext.version !== 'string' || !VERSION_RE.test(ext.version)) {
+        throw new UIIRValidationError(
+          'UINamespacedExtension.version must be a stable version token',
+        );
+      }
+      const root = ext.namespace.split('.', 1)[0];
+      const banned = new Set([
+        'observation',
+        'telemetry',
+        'projection',
+        'proof',
+        'policy_result',
+        'runtime',
+      ]);
+      if (banned.has(root)) {
+        throw new UIIRValidationError(
+          `UINamespacedExtension.namespace ${JSON.stringify(ext.namespace)} is not declaration content`,
+        );
+      }
+      rejectExecutablePayload(
+        ext.payload ?? {},
+        `UINamespacedExtension ${ext.extension_id}.payload`,
+      );
+    }
+  }
+
+  const sourceIds = new Set(document.sources.map(s => s.ref_id));
+  const componentIds = new Set(document.components.map(c => c.component_id));
+  const programIds = new Set(
+    (document.program_bindings ?? []).map(b => b.binding_id),
+  );
+  const feedbackIds = new Set(
+    (document.feedback_contracts ?? []).map(b => b.feedback_id),
+  );
+  const dataBindingIds = new Set(
+    ((document.data_bindings as Array<{ binding_id?: string }>) ?? []).map(b =>
+      String(b.binding_id ?? ''),
+    ),
+  );
+  const modalityIds = new Set<string>([
+    ...((document.input_modality_requirements as
+      | Array<{ requirement_id?: string }>
+      | undefined) ?? []).map(r => String(r.requirement_id ?? '')),
+    ...((document.output_modality_requirements as
+      | Array<{ requirement_id?: string }>
+      | undefined) ?? []).map(r => String(r.requirement_id ?? '')),
+  ]);
+
+  for (const component of document.components) {
+    requireKnownRefs(
+      component.source_ref_ids ?? [],
+      sourceIds,
+      `UIComponent ${JSON.stringify(component.component_id)}.source_ref_ids`,
+    );
+    if (component.parent_id) {
+      requireKnownRefs(
+        [component.parent_id],
+        componentIds,
+        `UIComponent ${JSON.stringify(component.component_id)}.parent_id`,
+      );
+    }
+    requireKnownRefs(
+      component.child_ids ?? [],
+      componentIds,
+      `UIComponent ${JSON.stringify(component.component_id)}.child_ids`,
+    );
+    if ((component.feedback_ids ?? []).length > 0) {
+      requireKnownRefs(
+        component.feedback_ids ?? [],
+        feedbackIds,
+        `UIComponent ${JSON.stringify(component.component_id)}.feedback_ids`,
+      );
+    }
+    if ((component.program_binding_ids ?? []).length > 0) {
+      requireKnownRefs(
+        component.program_binding_ids ?? [],
+        programIds,
+        `UIComponent ${JSON.stringify(component.component_id)}.program_binding_ids`,
+      );
+    }
+    if ((component.data_binding_ids ?? []).length > 0) {
+      requireKnownRefs(
+        component.data_binding_ids ?? [],
+        dataBindingIds,
+        `UIComponent ${JSON.stringify(component.component_id)}.data_binding_ids`,
+      );
+    }
+    if ((component.modality_binding_ids ?? []).length > 0) {
+      requireKnownRefs(
+        component.modality_binding_ids ?? [],
+        modalityIds,
+        `UIComponent ${JSON.stringify(component.component_id)}.modality_binding_ids`,
+      );
+    }
+  }
+
+  requireKnownRefs(
+    document.entry_components,
+    componentIds,
+    'UIIRDocument.entry_components',
+  );
+
+  for (const outcome of document.terminal_outcomes) {
+    requireKnownRefs(
+      outcome.source_ref_ids ?? [],
+      sourceIds,
+      `UITerminalOutcome ${JSON.stringify(outcome.outcome_id)}.source_ref_ids`,
+    );
+  }
+
+  for (const binding of document.program_bindings ?? []) {
+    requireKnownRefs(
+      binding.source_ref_ids ?? [],
+      sourceIds,
+      `UIProgramBinding ${JSON.stringify(binding.binding_id)}.source_ref_ids`,
+    );
+  }
+
+  for (const binding of document.mcp_idl_bindings ?? []) {
+    requireKnownRefs(
+      binding.source_ref_ids ?? [],
+      sourceIds,
+      `UIMCPIDLBinding ${JSON.stringify(binding.binding_id)}.source_ref_ids`,
+    );
+  }
+
+  for (const feedback of document.feedback_contracts ?? []) {
+    requireKnownRefs(
+      feedback.source_ref_ids ?? [],
+      sourceIds,
+      `UIFeedbackContract ${JSON.stringify(feedback.feedback_id)}.source_ref_ids`,
+    );
+    if (feedback.component_id) {
+      requireKnownRefs(
+        [feedback.component_id],
+        componentIds,
+        `UIFeedbackContract ${JSON.stringify(feedback.feedback_id)}.component_id`,
+      );
+    }
+  }
+
+  for (const region of document.layout_regions ?? []) {
+    requireKnownRefs(
+      region.source_ref_ids ?? [],
+      sourceIds,
+      `UILayoutRegion ${JSON.stringify(region.region_id)}.source_ref_ids`,
+    );
+    requireKnownRefs(
+      region.component_ids ?? [],
+      componentIds,
+      `UILayoutRegion ${JSON.stringify(region.region_id)}.component_ids`,
+    );
+  }
+
+  if ((document.states ?? []).length > 0 && !(document.initial_states ?? []).length) {
+    throw new UIIRValidationError(
+      'UIIRDocument.initial_states must not be empty when states are declared',
+    );
+  }
+
+  rejectExecutablePayload(uiIrToDict(document), 'UIIRDocument');
+  return document;
+}
+
+export const validateUIIR = validateUiIr;
+export const validate_ui_ir = validateUiIr;
+
+// ---------------------------------------------------------------------------
+// Decode (mirror Python decoder.py + optional closed collections)
+// ---------------------------------------------------------------------------
+
+function decodeSource(payload: Record<string, unknown>): UISourceRef {
+  const spanRaw = payload.span;
+  let span: SourceSpan | null = null;
+  if (spanRaw !== undefined && spanRaw !== null) {
+    const spanMap = requireObject(spanRaw, 'UISourceRef.span');
+    span = {
+      start_char: Number(spanMap.start_char ?? 0),
+      end_char: Number(spanMap.end_char ?? 0),
+    };
+  }
+  return {
+    ref_id: String(payload.ref_id ?? ''),
+    source_uri: String(payload.source_uri ?? ''),
+    source_id: String(payload.source_id ?? ''),
+    source_revision: String(payload.source_revision ?? ''),
+    content_sha256: String(payload.content_sha256 ?? ''),
+    container_uri: String(payload.container_uri ?? ''),
+    container_sha256: String(payload.container_sha256 ?? ''),
+    content_cid: String(payload.content_cid ?? ''),
+    license_expression: String(payload.license_expression ?? ''),
+    review_status: String(
+      payload.review_status ?? ReviewStatus.UNREVIEWED,
+    ) as ReviewStatus,
+    span,
+  };
+}
+
+function decodeComponent(payload: Record<string, unknown>): UIComponent {
+  // Fail closed on executable callback keys before stripping unknown fields.
+  rejectExecutablePayload(payload, 'UIComponent');
+  // Set-like id collections are unique (order of first appearance preserved for
+  // child_ids which are ordered; other id lists are normalized unique).
+  const childIds = asStringArray(payload.child_ids, 'UIComponent.child_ids');
+  return {
+    component_id: String(payload.component_id ?? ''),
+    role: String(payload.role ?? ''),
+    purpose: String(payload.purpose ?? ''),
+    accessible_name_ref: String(payload.accessible_name_ref ?? ''),
+    accessible_description_ref: String(
+      payload.accessible_description_ref ?? '',
+    ),
+    parent_id: String(payload.parent_id ?? ''),
+    child_ids: childIds,
+    modality_binding_ids: sortedUniqueStrings(
+      asStringArray(
+        payload.modality_binding_ids,
+        'UIComponent.modality_binding_ids',
+      ),
+    ),
+    data_binding_ids: sortedUniqueStrings(
+      asStringArray(payload.data_binding_ids, 'UIComponent.data_binding_ids'),
+    ),
+    program_binding_ids: sortedUniqueStrings(
+      asStringArray(
+        payload.program_binding_ids,
+        'UIComponent.program_binding_ids',
+      ),
+    ),
+    feedback_ids: sortedUniqueStrings(
+      asStringArray(payload.feedback_ids, 'UIComponent.feedback_ids'),
+    ),
+    privacy_sensitivity: String(payload.privacy_sensitivity ?? 'none'),
+    presentation_classification: String(
+      payload.presentation_classification ?? 'interactive',
+    ),
+    source_ref_ids: sortedUniqueStrings(
+      asStringArray(payload.source_ref_ids, 'UIComponent.source_ref_ids'),
+    ),
+  };
+}
+
+function decodeTerminal(payload: Record<string, unknown>): UITerminalOutcome {
+  return {
+    outcome_id: String(payload.outcome_id ?? ''),
+    kind: String(payload.kind ?? TerminalOutcomeKind.SUCCESS),
+    description: String(payload.description ?? ''),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UITerminalOutcome.source_ref_ids',
+    ),
+  };
+}
+
+function decodeLocale(payload: unknown): UILocaleDefaults {
+  if (!payload) {
+    return { default_locale: 'en', fallback_locales: [], text_direction: 'ltr' };
+  }
+  const data = requireObject(payload, 'locale_defaults');
+  return {
+    default_locale: String(data.default_locale ?? 'en'),
+    fallback_locales: asStringArray(
+      data.fallback_locales,
+      'locale_defaults.fallback_locales',
+    ),
+    text_direction: String(data.text_direction ?? 'ltr'),
+  };
+}
+
+function decodeRecordArray<T>(
+  value: unknown,
+  label: string,
+  decodeOne: (item: Record<string, unknown>) => T,
+): T[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new UIIRDecodeError(`${label} must be an array`);
+  }
+  return value.map((item, index) =>
+    decodeOne(requireObject(item, `${label}[${index}]`)),
+  );
+}
+
+function decodeProgramBinding(
+  payload: Record<string, unknown>,
+): UIProgramBinding {
+  return {
+    binding_id: String(payload.binding_id ?? ''),
+    target_kind: String(payload.target_kind ?? ''),
+    target_ref: String(payload.target_ref ?? ''),
+    risk_class: String(payload.risk_class ?? 'low'),
+    confirmation_class: String(payload.confirmation_class ?? 'none'),
+    precondition_ids: asStringArray(
+      payload.precondition_ids,
+      'UIProgramBinding.precondition_ids',
+    ),
+    effect_ids: asStringArray(
+      payload.effect_ids,
+      'UIProgramBinding.effect_ids',
+    ),
+    verification_ids: asStringArray(
+      payload.verification_ids,
+      'UIProgramBinding.verification_ids',
+    ),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UIProgramBinding.source_ref_ids',
+    ),
+  };
+}
+
+function decodeMcpIdlBinding(
+  payload: Record<string, unknown>,
+): UIMCPIDLBinding {
+  return {
+    binding_id: String(payload.binding_id ?? ''),
+    interface_cid: String(payload.interface_cid ?? ''),
+    method_name: String(payload.method_name ?? ''),
+    argument_schema_ref: String(payload.argument_schema_ref ?? ''),
+    result_schema_ref: String(payload.result_schema_ref ?? ''),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UIMCPIDLBinding.source_ref_ids',
+    ),
+  };
+}
+
+function decodeFeedback(payload: Record<string, unknown>): UIFeedbackContract {
+  return {
+    feedback_id: String(payload.feedback_id ?? ''),
+    channel: String(payload.channel ?? ''),
+    component_id: String(payload.component_id ?? ''),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UIFeedbackContract.source_ref_ids',
+    ),
+  };
+}
+
+function decodeLayoutRegion(payload: Record<string, unknown>): UILayoutRegion {
+  return {
+    region_id: String(payload.region_id ?? ''),
+    kind: String(payload.kind ?? LayoutRegionKind.FLOW),
+    component_ids: asStringArray(
+      payload.component_ids,
+      'UILayoutRegion.component_ids',
+    ),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UILayoutRegion.source_ref_ids',
+    ),
+  };
+}
+
+function decodeStateVariable(
+  payload: Record<string, unknown>,
+): UIStateVariable {
+  return {
+    variable_id: String(payload.variable_id ?? ''),
+    value_type: String(payload.value_type ?? ''),
+    derived: Boolean(payload.derived ?? false),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UIStateVariable.source_ref_ids',
+    ),
+  };
+}
+
+function decodeEvent(payload: Record<string, unknown>): UIEvent {
+  return {
+    event_id: String(payload.event_id ?? ''),
+    kind: String(payload.kind ?? 'domain'),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UIEvent.source_ref_ids',
+    ),
+  };
+}
+
+function decodeTask(payload: Record<string, unknown>): UIUXTask {
+  return {
+    task_id: String(payload.task_id ?? ''),
+    name: String(payload.name ?? ''),
+    step_component_ids: asStringArray(
+      payload.step_component_ids,
+      'UIUXTask.step_component_ids',
+    ),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UIUXTask.source_ref_ids',
+    ),
+  };
+}
+
+function decodeJourney(payload: Record<string, unknown>): UIJourney {
+  return {
+    journey_id: String(payload.journey_id ?? ''),
+    name: String(payload.name ?? ''),
+    task_ids: asStringArray(payload.task_ids, 'UIJourney.task_ids'),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UIJourney.source_ref_ids',
+    ),
+  };
+}
+
+function decodeTrust(payload: Record<string, unknown>): UITrustBinding {
+  return {
+    trust_id: String(payload.trust_id ?? ''),
+    authority_kind: String(payload.authority_kind ?? AuthorityKind.INTERFACE),
+    subject_ref: String(payload.subject_ref ?? ''),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UITrustBinding.source_ref_ids',
+    ),
+  };
+}
+
+function decodeExtension(
+  payload: Record<string, unknown>,
+): UINamespacedExtension {
+  const rawPayload = payload.payload;
+  if (
+    rawPayload !== undefined &&
+    rawPayload !== null &&
+    !isPlainObject(rawPayload)
+  ) {
+    throw new UIIRDecodeError('UINamespacedExtension.payload must be an object');
+  }
+  return {
+    extension_id: String(payload.extension_id ?? ''),
+    namespace: String(payload.namespace ?? ''),
+    version: String(payload.version ?? ''),
+    payload: isPlainObject(rawPayload)
+      ? { ...(rawPayload as Record<string, unknown>) }
+      : {},
+    required: Boolean(payload.required ?? false),
+    source_ref_ids: asStringArray(
+      payload.source_ref_ids,
+      'UINamespacedExtension.source_ref_ids',
+    ),
+  };
+}
+
+function parsePayload(
+  payload: unknown,
+): Record<string, unknown> {
+  if (typeof payload === 'string') {
+    try {
+      payload = JSON.parse(payload);
+    } catch (exc) {
+      throw new UIIRDecodeError(
+        `UI/UX IR payload is not valid JSON: ${String(exc)}`,
+      );
+    }
+  } else if (payload instanceof Uint8Array) {
+    try {
+      const text = new TextDecoder('utf-8', { fatal: true }).decode(payload);
+      payload = JSON.parse(text);
+    } catch (exc) {
+      throw new UIIRDecodeError(
+        `UI/UX IR payload is not valid UTF-8 JSON: ${String(exc)}`,
+      );
+    }
+  }
+  if (!isPlainObject(payload)) {
+    throw new UIIRDecodeError('UI/UX IR payload must decode to an object');
+  }
+  return payload;
+}
+
+/**
+ * Decode a wire payload into a validated UIIRDocument.
+ * Unknown versions and unknown top-level fields fail closed.
+ * Legacy versions require explicit migration before decode.
+ */
+export function decodeUiIr(
+  payload: unknown,
+): UIIRDocument {
+  const raw = parsePayload(payload);
+  const version = String(raw.schema_version ?? '');
+  if (!version) {
+    throw new UIIRDecodeError('UI/UX IR payload missing schema_version');
+  }
+  if (version === LEGACY_UI_UX_IR_SCHEMA_VERSION) {
+    throw new UIIRDecodeError(
+      `Legacy schema_version ${JSON.stringify(version)} requires explicit migration before decode`,
+    );
+  }
+  if (version !== UI_UX_IR_SCHEMA_VERSION) {
+    throw new UIIRDecodeError(
+      `Unsupported schema_version ${JSON.stringify(version)}; expected ${JSON.stringify(UI_UX_IR_SCHEMA_VERSION)}`,
+    );
+  }
+
+  try {
+    rejectUnknownDocumentFields(raw);
+  } catch (exc) {
+    if (exc instanceof UIIRValidationError) {
+      throw new UIIRDecodeError(exc.message);
+    }
+    throw exc;
+  }
+
+  const sourcesRaw = raw.sources ?? [];
+  const componentsRaw = raw.components ?? [];
+  const terminalsRaw = raw.terminal_outcomes ?? [];
+  if (!Array.isArray(sourcesRaw)) {
+    throw new UIIRDecodeError('sources must be an array');
+  }
+  if (!Array.isArray(componentsRaw)) {
+    throw new UIIRDecodeError('components must be an array');
+  }
+  if (!Array.isArray(terminalsRaw)) {
+    throw new UIIRDecodeError('terminal_outcomes must be an array');
+  }
+
+  let document: UIIRDocument;
+  try {
+    const producerRaw = raw.producer;
+    const configurationRaw = raw.configuration;
+    const reviewRaw = raw.review;
+
+    document = {
+      schema_version: version,
+      document_id: String(raw.document_id ?? ''),
+      title: String(raw.title ?? ''),
+      sources: sourcesRaw.map((item, index) =>
+        decodeSource(requireObject(item, `sources[${index}]`)),
+      ),
+      components: componentsRaw.map((item, index) =>
+        decodeComponent(requireObject(item, `components[${index}]`)),
+      ),
+      entry_components: sortedUniqueStrings(
+        asStringArray(raw.entry_components, 'entry_components'),
+      ),
+      terminal_outcomes: terminalsRaw.map((item, index) =>
+        decodeTerminal(requireObject(item, `terminal_outcomes[${index}]`)),
+      ),
+      locale_defaults: decodeLocale(raw.locale_defaults),
+      tags: asStringArray(raw.tags, 'tags'),
+      producer:
+        producerRaw === undefined || producerRaw === null
+          ? null
+          : {
+              producer_id: String(
+                requireObject(producerRaw, 'producer').producer_id ?? '',
+              ),
+              name: String(requireObject(producerRaw, 'producer').name ?? ''),
+              version: String(
+                requireObject(producerRaw, 'producer').version ?? '',
+              ),
+            },
+      configuration:
+        configurationRaw === undefined || configurationRaw === null
+          ? null
+          : {
+              configuration_id: String(
+                requireObject(configurationRaw, 'configuration')
+                  .configuration_id ?? '',
+              ),
+              profile: String(
+                requireObject(configurationRaw, 'configuration').profile ??
+                  'default',
+              ),
+              settings: isPlainObject(
+                requireObject(configurationRaw, 'configuration').settings,
+              )
+                ? {
+                    ...(requireObject(configurationRaw, 'configuration')
+                      .settings as Record<string, unknown>),
+                  }
+                : {},
+            },
+      review:
+        reviewRaw === undefined || reviewRaw === null
+          ? {
+              review_status: ReviewStatus.UNREVIEWED,
+              reviewer: '',
+              notes: '',
+            }
+          : {
+              review_status: String(
+                requireObject(reviewRaw, 'review').review_status ??
+                  ReviewStatus.UNREVIEWED,
+              ),
+              reviewer: String(
+                requireObject(reviewRaw, 'review').reviewer ?? '',
+              ),
+              notes: String(requireObject(reviewRaw, 'review').notes ?? ''),
+            },
+      trust_bindings: decodeRecordArray(
+        raw.trust_bindings,
+        'trust_bindings',
+        decodeTrust,
+      ),
+      composition_edges: Array.isArray(raw.composition_edges)
+        ? [...raw.composition_edges]
+        : [],
+      layout_regions: decodeRecordArray(
+        raw.layout_regions,
+        'layout_regions',
+        decodeLayoutRegion,
+      ),
+      layout_constraints: Array.isArray(raw.layout_constraints)
+        ? [...raw.layout_constraints]
+        : [],
+      design_token_refs: Array.isArray(raw.design_token_refs)
+        ? [...raw.design_token_refs]
+        : [],
+      state_variables: decodeRecordArray(
+        raw.state_variables,
+        'state_variables',
+        decodeStateVariable,
+      ),
+      states: Array.isArray(raw.states) ? [...raw.states] : [],
+      events: decodeRecordArray(raw.events, 'events', decodeEvent),
+      transitions: Array.isArray(raw.transitions) ? [...raw.transitions] : [],
+      guards: Array.isArray(raw.guards) ? [...raw.guards] : [],
+      effects: Array.isArray(raw.effects) ? [...raw.effects] : [],
+      ux_tasks: decodeRecordArray(raw.ux_tasks, 'ux_tasks', decodeTask),
+      journeys: decodeRecordArray(raw.journeys, 'journeys', decodeJourney),
+      success_failure_recovery: Array.isArray(raw.success_failure_recovery)
+        ? [...raw.success_failure_recovery]
+        : [],
+      feedback_contracts: decodeRecordArray(
+        raw.feedback_contracts,
+        'feedback_contracts',
+        decodeFeedback,
+      ),
+      accessibility: Array.isArray(raw.accessibility)
+        ? [...raw.accessibility]
+        : [],
+      localization: Array.isArray(raw.localization) ? [...raw.localization] : [],
+      input_modality_requirements: Array.isArray(raw.input_modality_requirements)
+        ? [...raw.input_modality_requirements]
+        : [],
+      output_modality_requirements: Array.isArray(
+        raw.output_modality_requirements,
+      )
+        ? [...raw.output_modality_requirements]
+        : [],
+      modality_alternatives: Array.isArray(raw.modality_alternatives)
+        ? [...raw.modality_alternatives]
+        : [],
+      device_capability_requirements: Array.isArray(
+        raw.device_capability_requirements,
+      )
+        ? [...raw.device_capability_requirements]
+        : [],
+      adaptive_variants: Array.isArray(raw.adaptive_variants)
+        ? [...raw.adaptive_variants]
+        : [],
+      data_bindings: Array.isArray(raw.data_bindings)
+        ? [...raw.data_bindings]
+        : [],
+      content_references: Array.isArray(raw.content_references)
+        ? [...raw.content_references]
+        : [],
+      program_bindings: decodeRecordArray(
+        raw.program_bindings,
+        'program_bindings',
+        decodeProgramBinding,
+      ),
+      intent_ir_bindings: Array.isArray(raw.intent_ir_bindings)
+        ? [...raw.intent_ir_bindings]
+        : [],
+      invocation_bindings: Array.isArray(raw.invocation_bindings)
+        ? [...raw.invocation_bindings]
+        : [],
+      mcp_idl_bindings: decodeRecordArray(
+        raw.mcp_idl_bindings,
+        'mcp_idl_bindings',
+        decodeMcpIdlBinding,
+      ),
+      formal_constraint_refs: Array.isArray(raw.formal_constraint_refs)
+        ? [...raw.formal_constraint_refs]
+        : [],
+      proof_obligation_refs: Array.isArray(raw.proof_obligation_refs)
+        ? [...raw.proof_obligation_refs]
+        : [],
+      initial_states: asStringArray(raw.initial_states, 'initial_states'),
+      extensions: decodeRecordArray(
+        raw.extensions,
+        'extensions',
+        decodeExtension,
+      ),
+    };
+  } catch (exc) {
+    if (exc instanceof UIIRValidationError) {
+      throw new UIIRDecodeError(exc.message);
+    }
+    throw new UIIRDecodeError(
+      `Failed to decode UI/UX IR document: ${String(exc)}`,
+    );
+  }
+
+  try {
+    return validateUiIr(document);
+  } catch (exc) {
+    if (exc instanceof UIIRValidationError) {
+      throw new UIIRDecodeError(exc.message);
+    }
+    throw exc;
+  }
+}
+
+export const decodeUIIR = decodeUiIr;
+export const decode_ui_ir = decodeUiIr;
+
+// ---------------------------------------------------------------------------
+// SwissKnife MCP UI profile conversion (lossy, fully reported)
+// ---------------------------------------------------------------------------
+
+function regionKindFromSection(
+  kind: MCPUISection['kind'] | string | undefined,
+): LayoutRegionKind {
+  switch (kind) {
+    case 'table':
+    case 'graph':
+      return LayoutRegionKind.GRID;
+    case 'timeline':
+    case 'status':
+    case 'audit':
+      return LayoutRegionKind.FLOW;
+    case 'form':
+    case 'command-bar':
+      return LayoutRegionKind.STACK;
+    default:
+      return LayoutRegionKind.FLOW;
+  }
+}
+
+/**
+ * Convert a SwissKnife MCP++ UI profile descriptor into a UIIR document.
+ * Retains every mapped semantic and lists every unmapped loss explicitly.
+ */
+export function convertMcpUiProfileToUiIr(
+  profile: MCPUIProfileDescriptor,
+  options: {
+    sourceUri?: string;
+    sourceRevision?: string;
+    contentSha256?: string;
+  } = {},
+): UIIRProfileConversionResult {
+  const losses: UIIRConversionLoss[] = [];
+  const appId = profile.meta?.app_id || profile.name || 'unknown-app';
+  const documentId = stableId(`doc:${appId}`, 'doc');
+  const sourceRefId = stableId(`source:mcp-ui-profile:${appId}`, 'source');
+  const contentSha256 =
+    options.contentSha256 ??
+    sha256Hex(
+      JSON.stringify({
+        name: profile.name,
+        namespace: profile.namespace,
+        version: profile.version,
+        app_id: profile.meta?.app_id,
+      }),
+    );
+
+  const source: UISourceRef = {
+    ref_id: sourceRefId,
+    source_uri:
+      options.sourceUri ??
+      `swissknife:mcp-ui-profile:${profile.namespace ?? 'local'}/${appId}`,
+    source_id: appId,
+    source_revision:
+      options.sourceRevision ??
+      String(profile.meta?.profile_version ?? profile.version ?? '0'),
+    content_sha256: contentSha256,
+    review_status: ReviewStatus.MACHINE_EXTRACTED,
+    span: null,
+  };
+
+  const components: UIComponent[] = [];
+  const programBindings: UIProgramBinding[] = [];
+  const mcpIdlBindings: UIMCPIDLBinding[] = [];
+  const layoutRegions: UILayoutRegion[] = [];
+  const feedbackContracts: UIFeedbackContract[] = [];
+  const stateVariables: UIStateVariable[] = [];
+  const events: UIEvent[] = [];
+  const uxTasks: UIUXTask[] = [];
+  const journeys: UIJourney[] = [];
+  const trustBindings: UITrustBinding[] = [];
+  const extensions: UINamespacedExtension[] = [];
+
+  const rootId = stableId(`component:root:${appId}`, 'component');
+  const rootChildIds: string[] = [];
+
+  // Map methods / operations -> components + program + mcp-idl bindings.
+  const methods = profile.methods ?? [];
+  const operations = profile.data_contracts?.operations ?? [];
+  const methodNames = new Set(methods.map(m => m.name));
+
+  for (const method of methods) {
+    const componentId = stableId(`component:method:${method.name}`, 'component');
+    const programId = stableId(`program:${method.name}`, 'program');
+    const mcpId = stableId(`mcp-idl:${method.name}`, 'mcp-idl');
+    rootChildIds.push(componentId);
+
+    components.push({
+      component_id: componentId,
+      role: 'button',
+      purpose: `Invoke MCP method ${method.name}`,
+      parent_id: rootId,
+      program_binding_ids: [programId],
+      source_ref_ids: [sourceRefId],
+      presentation_classification: 'interactive',
+      privacy_sensitivity: 'none',
+    });
+
+    programBindings.push({
+      binding_id: programId,
+      target_kind: ProgramBindingTargetKind.MCP_IDL,
+      target_ref: `mcp:${profile.namespace ?? 'local'}/${method.name}`,
+      risk_class: 'medium',
+      confirmation_class: 'none',
+      source_ref_ids: [sourceRefId],
+    });
+
+    const interfaceCid =
+      profile.services?.find(s => s.operations?.includes(method.name))
+        ?.interface_cid ??
+      `legacy-alias:interface:${profile.namespace ?? 'local'}/${profile.name ?? appId}`;
+
+    mcpIdlBindings.push({
+      binding_id: mcpId,
+      interface_cid: interfaceCid,
+      method_name: method.name,
+      argument_schema_ref: '',
+      result_schema_ref: '',
+      source_ref_ids: [sourceRefId],
+    });
+
+    // Detailed method schemas are referenced, not embedded as executable code.
+    if (method.input_schema) {
+      losses.push({
+        path: `methods[${method.name}].input_schema`,
+        reason:
+          'JSON Schema bodies are not declaration content; retain only method identity and external schema refs in UIIR',
+      });
+    }
+    if (method.output_schema) {
+      losses.push({
+        path: `methods[${method.name}].output_schema`,
+        reason:
+          'JSON Schema bodies are not declaration content; retain only method identity and external schema refs in UIIR',
+      });
+    }
+  }
+
+  for (const operation of operations) {
+    if (!methodNames.has(operation.method)) {
+      losses.push({
+        path: `data_contracts.operations[${operation.method}]`,
+        reason:
+          'Operation contract without matching MCP-IDL method is retained only as loss (no silent method synthesis)',
+        source_value: operation.method,
+      });
+    }
+    if (operation.stream && operation.stream.kind !== 'none') {
+      losses.push({
+        path: `data_contracts.operations[${operation.method}].stream`,
+        reason:
+          'Stream contracts are runtime/transport concerns, not UIIR declaration content',
+        source_value: operation.stream,
+      });
+    }
+    if (operation.retry_policy) {
+      losses.push({
+        path: `data_contracts.operations[${operation.method}].retry_policy`,
+        reason: 'Retry policy is mediation/runtime policy, not UIIR declaration content',
+        source_value: operation.retry_policy,
+      });
+    }
+    if (operation.input_schema_cid || operation.output_schema_cid) {
+      // Schema CIDs are identity-adjacent but not mapped into closed v1 leaves
+      // beyond program/mcp bindings; report explicitly.
+      losses.push({
+        path: `data_contracts.operations[${operation.method}].schema_cids`,
+        reason:
+          'Operation schema CIDs are not a closed UIIR v1 leaf; use mcp_idl_bindings and external identity vectors',
+        source_value: {
+          input_schema_cid: operation.input_schema_cid,
+          output_schema_cid: operation.output_schema_cid,
+        },
+      });
+    }
+  }
+
+  // UI templates / sections / regions -> layout regions + tasks.
+  const templates: MCPUITemplateMapping[] = profile.ui?.templates ?? [];
+  const sections: MCPUISection[] = profile.ui?.sections ?? [];
+  const primaryTemplate = profile.ui?.primary_template;
+
+  components.unshift({
+    component_id: rootId,
+    role: 'application',
+    purpose: profile.meta?.description || profile.meta?.title || profile.name,
+    accessible_name_ref: '',
+    child_ids: rootChildIds,
+    source_ref_ids: [sourceRefId],
+    presentation_classification: 'interactive',
+    privacy_sensitivity: 'none',
+  });
+
+  if (primaryTemplate) {
+    layoutRegions.push({
+      region_id: stableId(`region:primary:${primaryTemplate}`, 'region'),
+      kind: LayoutRegionKind.STACK,
+      component_ids: [rootId, ...rootChildIds],
+      source_ref_ids: [sourceRefId],
+    });
+  }
+
+  for (const template of templates) {
+    const taskId = stableId(`task:template:${template.kind}`, 'task');
+    const stepIds = (template.operations ?? [])
+      .map(op => stableId(`component:method:${op}`, 'component'))
+      .filter(id => components.some(c => c.component_id === id));
+    uxTasks.push({
+      task_id: taskId,
+      name: template.title || template.kind,
+      step_component_ids: stepIds.length ? stepIds : [rootId],
+      source_ref_ids: [sourceRefId],
+    });
+    for (const region of template.regions ?? []) {
+      const componentForOp = region.operation
+        ? stableId(`component:method:${region.operation}`, 'component')
+        : rootId;
+      layoutRegions.push({
+        region_id: stableId(`region:${template.kind}:${region.id}`, 'region'),
+        kind: regionKindFromSection(region.kind),
+        component_ids: components.some(c => c.component_id === componentForOp)
+          ? [componentForOp]
+          : [rootId],
+        source_ref_ids: [sourceRefId],
+      });
+    }
+  }
+
+  for (const section of sections) {
+    layoutRegions.push({
+      region_id: stableId(`region:section:${section.id}`, 'region'),
+      kind: regionKindFromSection(section.kind),
+      component_ids: section.operation
+        ? [
+            components.some(
+              c =>
+                c.component_id ===
+                stableId(`component:method:${section.operation}`, 'component'),
+            )
+              ? stableId(`component:method:${section.operation}`, 'component')
+              : rootId,
+          ]
+        : [rootId],
+      source_ref_ids: [sourceRefId],
+    });
+  }
+
+  if (uxTasks.length > 0) {
+    journeys.push({
+      journey_id: stableId(`journey:${appId}`, 'journey'),
+      name: profile.meta?.title || profile.name,
+      task_ids: uxTasks.map(t => t.task_id),
+      source_ref_ids: [sourceRefId],
+    });
+  }
+
+  // State model keys/events.
+  for (const key of profile.state_model?.keys ?? []) {
+    stateVariables.push({
+      variable_id: stableId(`state-var:${key}`, 'state-var'),
+      value_type: 'unknown',
+      derived: false,
+      source_ref_ids: [sourceRefId],
+    });
+  }
+  for (const eventName of profile.state_model?.events ?? []) {
+    events.push({
+      event_id: stableId(`event:${eventName}`, 'event'),
+      kind: 'domain',
+      source_ref_ids: [sourceRefId],
+    });
+  }
+  if (profile.state_model?.projections?.length) {
+    losses.push({
+      path: 'state_model.projections',
+      reason:
+        'State projections are derived runtime views, not UIIR declaration content',
+      source_value: profile.state_model.projections,
+    });
+  }
+  if (profile.state_model?.replay) {
+    losses.push({
+      path: 'state_model.replay',
+      reason: 'Replay capability is runtime policy, not UIIR declaration content',
+      source_value: profile.state_model.replay,
+    });
+  }
+
+  // Permissions are authorization policy, never UI visibility authority.
+  if (profile.permissions) {
+    losses.push({
+      path: 'permissions',
+      reason:
+        'Permission maps are runtime authorization policy and must not be encoded as UIIR visibility/enabled state',
+      source_value: profile.permissions,
+    });
+  }
+
+  // Services transport/endpoints are runtime, not declaration.
+  for (const service of profile.services ?? []) {
+    if (service.transport || service.endpoint) {
+      losses.push({
+        path: `services[${service.id}].transport_endpoint`,
+        reason:
+          'Service transport/endpoint bindings are runtime routing, not UIIR declaration content',
+        source_value: {
+          transport: service.transport,
+          endpoint: service.endpoint,
+        },
+      });
+    }
+    if (service.interface_type) {
+      // interface_type is retained only indirectly via tags/extensions.
+    }
+  }
+
+  // Workflow graph -> journey/tasks when present; residual details as losses.
+  if (profile.workflow_graph) {
+    const wf = profile.workflow_graph;
+    const wfTaskId = stableId(`task:workflow:${wf.id}`, 'task');
+    const stepComponentIds = (wf.steps ?? []).map(step =>
+      stableId(`component:method:${step.operation}`, 'component'),
+    );
+    uxTasks.push({
+      task_id: wfTaskId,
+      name: wf.title || wf.id,
+      step_component_ids: stepComponentIds.filter(id =>
+        components.some(c => c.component_id === id),
+      ),
+      source_ref_ids: [sourceRefId],
+    });
+    for (const step of wf.steps ?? []) {
+      if (step.depends_on?.length) {
+        losses.push({
+          path: `workflow_graph.steps[${step.id}].depends_on`,
+          reason:
+            'Workflow step dependency edges are not a closed UIIR v1 behavior edge; retained as loss pending behavior model binding',
+          source_value: step.depends_on,
+        });
+      }
+      if (step.rollback || step.compensation) {
+        losses.push({
+          path: `workflow_graph.steps[${step.id}].rollback_compensation`,
+          reason:
+            'Rollback/compensation actions require Intent/Invocation bindings not present on the UI profile alone',
+          source_value: {
+            rollback: step.rollback,
+            compensation: step.compensation,
+          },
+        });
+      }
+      if (step.read_state_keys || step.write_state_keys) {
+        losses.push({
+          path: `workflow_graph.steps[${step.id}].state_keys`,
+          reason:
+            'Per-step state read/write keys are runtime state-machine detail beyond mapped state_variables',
+          source_value: {
+            read_state_keys: step.read_state_keys,
+            write_state_keys: step.write_state_keys,
+          },
+        });
+      }
+    }
+    if (wf.shared_state_keys?.length) {
+      for (const key of wf.shared_state_keys) {
+        const varId = stableId(`state-var:${key}`, 'state-var');
+        if (!stateVariables.some(v => v.variable_id === varId)) {
+          stateVariables.push({
+            variable_id: varId,
+            value_type: 'unknown',
+            derived: false,
+            source_ref_ids: [sourceRefId],
+          });
+        }
+      }
+    }
+  }
+
+  // Control surface contract is mediation policy.
+  if (profile.control_surface_contract !== undefined) {
+    losses.push({
+      path: 'control_surface_contract',
+      reason:
+        'Control-surface mediation contracts belong to the broker/mediator path, not the immutable UIIR declaration',
+      source_value: profile.control_surface_contract,
+    });
+  }
+
+  // Trust metadata: retain subject identity; signature material is not declaration.
+  if (profile.trust) {
+    trustBindings.push({
+      trust_id: stableId(`trust:interface:${appId}`, 'trust'),
+      authority_kind: AuthorityKind.INTERFACE,
+      subject_ref: profile.trust.canonical_cid || profile.name,
+      source_ref_ids: [sourceRefId],
+    });
+    losses.push({
+      path: 'trust.signature_material',
+      reason:
+        'Descriptor signatures and signed_at are trust artifacts, not UIIR declaration content; only subject identity is mapped',
+      source_value: {
+        signed_by: profile.trust.signed_by,
+        signature_algorithm: profile.trust.signature_algorithm,
+        signature: profile.trust.signature,
+        signed_at: profile.trust.signed_at,
+      },
+    });
+  }
+
+  // Errors / requires / compatibility / observability / interaction patterns.
+  if (profile.errors?.length) {
+    losses.push({
+      path: 'errors',
+      reason:
+        'MCP-IDL error catalogs are interface identity, not UIIR terminal UX outcomes',
+      source_value: profile.errors,
+    });
+  }
+  if (profile.requires?.length) {
+    losses.push({
+      path: 'requires',
+      reason: 'MCP-IDL requires list is interface dependency metadata, not UIIR content',
+      source_value: profile.requires,
+    });
+  }
+  if (profile.compatibility) {
+    losses.push({
+      path: 'compatibility',
+      reason:
+        'MCP-IDL compatibility metadata is interface identity, not UIIR declaration content',
+      source_value: profile.compatibility,
+    });
+  }
+  if (profile.observability) {
+    losses.push({
+      path: 'observability',
+      reason: 'Observability flags are runtime telemetry policy, not UIIR declaration content',
+      source_value: profile.observability,
+    });
+  }
+  if (profile.interaction_patterns) {
+    losses.push({
+      path: 'interaction_patterns',
+      reason:
+        'Interaction pattern flags are interface capability metadata; only concrete methods/UI structure are mapped',
+      source_value: profile.interaction_patterns,
+    });
+  }
+  if (profile.data_contracts?.schemas) {
+    losses.push({
+      path: 'data_contracts.schemas',
+      reason:
+        'Named schema dictionary bodies are not UIIR declaration leaves; keep external schema identity',
+      source_value: Object.keys(profile.data_contracts.schemas),
+    });
+  }
+  if (profile.meta?.icon) {
+    losses.push({
+      path: 'meta.icon',
+      reason: 'Icon assets are presentation resources outside closed UIIR v1 leaves',
+      source_value: profile.meta.icon,
+    });
+  }
+  if (profile.meta?.publisher) {
+    losses.push({
+      path: 'meta.publisher',
+      reason: 'Publisher string is retained only via producer name when present',
+      source_value: profile.meta.publisher,
+    });
+  }
+  if (
+    profile.meta?.profile &&
+    profile.meta.profile !== SWISSKNIFE_MCP_UI_PROFILE
+  ) {
+    losses.push({
+      path: 'meta.profile',
+      reason: 'Non-standard UI profile identifier is recorded as conversion loss',
+      source_value: profile.meta.profile,
+    });
+  }
+
+  // Feedback surface for errors.
+  feedbackContracts.push({
+    feedback_id: stableId(`feedback:status:${appId}`, 'feedback'),
+    channel: 'status',
+    component_id: rootId,
+    source_ref_ids: [sourceRefId],
+  });
+
+  // Preserve residual SwissKnife profile identity in a namespaced extension
+  // (declaration content, not observation/runtime).
+  extensions.push({
+    extension_id: stableId(`ext:swissknife-ui-profile:${appId}`, 'ext'),
+    namespace: 'swissknife.mcp_ui_profile',
+    version: String(profile.meta?.profile_version ?? '0.1.0'),
+    required: false,
+    payload: {
+      profile: profile.meta?.profile ?? SWISSKNIFE_MCP_UI_PROFILE,
+      profile_version: profile.meta?.profile_version ?? null,
+      app_id: profile.meta?.app_id ?? appId,
+      primary_template: primaryTemplate ?? null,
+      service_ids: (profile.services ?? []).map(s => s.id),
+      interface_types: (profile.services ?? []).map(s => s.interface_type),
+    },
+    source_ref_ids: [sourceRefId],
+  });
+
+  const tags = [
+    ...(profile.semanticTags ?? []),
+    'swissknife-mcp-ui-profile',
+    primaryTemplate ?? '',
+  ].filter(Boolean);
+
+  const document: UIIRDocument = {
+    schema_version: UI_UX_IR_SCHEMA_VERSION,
+    document_id: documentId,
+    title: profile.meta?.title || profile.name || appId,
+    sources: [source],
+    components,
+    entry_components: [rootId],
+    terminal_outcomes: [
+      {
+        outcome_id: stableId(`outcome:success:${appId}`, 'outcome'),
+        kind: TerminalOutcomeKind.SUCCESS,
+        description: 'Primary UI interaction completed',
+        source_ref_ids: [sourceRefId],
+      },
+      {
+        outcome_id: stableId(`outcome:failure:${appId}`, 'outcome'),
+        kind: TerminalOutcomeKind.FAILURE,
+        description: 'Primary UI interaction failed',
+        source_ref_ids: [sourceRefId],
+      },
+    ],
+    locale_defaults: {
+      default_locale: 'en',
+      fallback_locales: ['en'],
+      text_direction: 'ltr',
+    },
+    tags,
+    producer: {
+      producer_id: 'producer:swissknife-ui-ux-ir-codec',
+      name: 'SwissKnife UI/UX IR codec',
+      version: '1.0.0',
+    },
+    configuration: {
+      configuration_id: stableId(`config:${appId}`, 'config'),
+      profile: 'swissknife-mcp-ui-profile',
+      settings: {
+        namespace: profile.namespace ?? '',
+        version: profile.version ?? '',
+        primary_template: primaryTemplate ?? '',
+      },
+    },
+    review: {
+      review_status: ReviewStatus.MACHINE_EXTRACTED,
+      reviewer: '',
+      notes: 'Converted from SwissKnife MCP++ UI profile',
+    },
+    trust_bindings: trustBindings,
+    layout_regions: layoutRegions,
+    state_variables: stateVariables,
+    events,
+    ux_tasks: uxTasks,
+    journeys,
+    feedback_contracts: feedbackContracts,
+    program_bindings: programBindings,
+    mcp_idl_bindings: mcpIdlBindings,
+    extensions,
+    initial_states: [],
+  };
+
+  // Validate mapped document; conversion must not emit invalid UIIR.
+  const validated = validateUiIr(document);
+
+  // Sort losses by path for stable receipts.
+  losses.sort((a, b) => a.path.localeCompare(b.path, 'en'));
+
+  return {
+    document: validated,
+    losses,
+    lossy: losses.length > 0,
+  };
+}
+
+export const convertMCPUIProfileToUIIR = convertMcpUiProfileToUiIr;
+
+/**
+ * Convenience: decode if needed, then return canonical identity digest.
+ */
+export function uiIrIdentity(
+  document: UIIRDocument | Record<string, unknown>,
+): { schema_version: string; digest: string; byte_length: number } {
+  const bytes = canonicalizeUiIr(document);
+  return {
+    schema_version: UI_UX_IR_SCHEMA_VERSION,
+    digest: `sha256:${sha256Hex(bytes)}`,
+    byte_length: bytes.byteLength,
+  };
+}

--- a/src/services/mcp/ui-ux-ir-web-renderer.ts
+++ b/src/services/mcp/ui-ux-ir-web-renderer.ts
@@ -1,0 +1,1797 @@
+/**
+ * UIIRWebRenderer@1 — bounded web/desktop accessible render models.
+ *
+ * Renders UI/UX IR projection artifacts and DOM/ARIA-derived semantic trees
+ * into deterministic accessible web models. Never executes imported markup or
+ * scripts. CSS/framework details are retained only as source metadata or
+ * explicit loss receipts. Denial, error, and confirmation surfaces remain
+ * visible and accessible.
+ *
+ * Mirrors Python `ipfs_datasets_py.logic.ui_ux_ir.projection.web`.
+ */
+
+export const UIIR_WEB_RENDERER_INTERFACE = 'UIIRWebRenderer@1' as const;
+export const UIIR_WEB_PROJECTION_INTERFACE = 'UIIRWebProjection@1' as const;
+export const UIIR_WEB_PROJECTION_SCHEMA_VERSION = 'ui-web-projection/v1' as const;
+export const UIIR_WEB_RENDER_MODEL_VERSION = 'ui-web-render-model/v1' as const;
+export const DOMARIA_UIIR_ADAPTER = 'DOMARIAUIIRAdapter@1' as const;
+export const POLICY_OWNER = 'UIProjectionSolver@1' as const;
+
+const IDENTIFIER_RE = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$/;
+
+const EXECUTABLE_TEXT_MARKERS = [
+  '<script',
+  '</script',
+  'javascript:',
+  'vbscript:',
+  'onerror=',
+  'onload=',
+  'onclick=',
+  'eval(',
+  'Function(',
+  'document.write',
+  'innerHTML',
+  '__proto__',
+] as const;
+
+const FORBIDDEN_TAGS = new Set([
+  'script',
+  'style',
+  'iframe',
+  'object',
+  'embed',
+  'applet',
+  'link',
+  'meta',
+  'base',
+  'template',
+  'noscript',
+]);
+
+const SUPPORTED_ARIA_ROLES = new Set([
+  'alert',
+  'alertdialog',
+  'application',
+  'banner',
+  'button',
+  'cell',
+  'checkbox',
+  'columnheader',
+  'combobox',
+  'complementary',
+  'contentinfo',
+  'dialog',
+  'document',
+  'form',
+  'grid',
+  'gridcell',
+  'group',
+  'heading',
+  'img',
+  'link',
+  'list',
+  'listbox',
+  'listitem',
+  'log',
+  'main',
+  'menu',
+  'menubar',
+  'menuitem',
+  'navigation',
+  'none',
+  'option',
+  'presentation',
+  'progressbar',
+  'radio',
+  'region',
+  'row',
+  'rowheader',
+  'search',
+  'separator',
+  'slider',
+  'spinbutton',
+  'status',
+  'switch',
+  'tab',
+  'table',
+  'tablist',
+  'tabpanel',
+  'textbox',
+  'toolbar',
+  'tooltip',
+  'tree',
+  'treeitem',
+]);
+
+const SUPPORTED_STATE_KEYS = new Set([
+  'busy',
+  'checked',
+  'current',
+  'disabled',
+  'expanded',
+  'haspopup',
+  'hidden',
+  'invalid',
+  'level',
+  'multiline',
+  'multiselectable',
+  'orientation',
+  'pressed',
+  'readonly',
+  'required',
+  'selected',
+  'valuemax',
+  'valuemin',
+  'valuenow',
+  'valuetext',
+]);
+
+const SUPPORTED_RELATIONSHIP_KEYS = new Set([
+  'activedescendant',
+  'controls',
+  'describedby',
+  'flowto',
+  'labelledby',
+  'owns',
+]);
+
+const SUPPORTED_ACTION_KINDS = new Set([
+  'activate',
+  'click',
+  'confirm',
+  'dismiss',
+  'edit',
+  'select',
+  'submit',
+  'toggle',
+]);
+
+const FOCUSABLE_ROLES = new Set([
+  'button',
+  'link',
+  'textbox',
+  'checkbox',
+  'radio',
+  'switch',
+  'combobox',
+  'listbox',
+  'option',
+  'slider',
+  'spinbutton',
+  'tab',
+  'menuitem',
+  'treeitem',
+  'search',
+  'dialog',
+  'alertdialog',
+]);
+
+const ROLE_DEFAULT_TAG: Readonly<Record<string, string>> = Object.freeze({
+  alert: 'div',
+  alertdialog: 'div',
+  application: 'div',
+  banner: 'header',
+  button: 'button',
+  cell: 'td',
+  checkbox: 'input',
+  columnheader: 'th',
+  combobox: 'div',
+  complementary: 'aside',
+  contentinfo: 'footer',
+  dialog: 'div',
+  document: 'article',
+  form: 'form',
+  grid: 'table',
+  gridcell: 'td',
+  group: 'div',
+  heading: 'h2',
+  img: 'img',
+  link: 'a',
+  list: 'ul',
+  listbox: 'div',
+  listitem: 'li',
+  log: 'div',
+  main: 'main',
+  menu: 'ul',
+  menubar: 'ul',
+  menuitem: 'li',
+  navigation: 'nav',
+  none: 'div',
+  option: 'div',
+  presentation: 'div',
+  progressbar: 'div',
+  radio: 'input',
+  region: 'section',
+  row: 'tr',
+  rowheader: 'th',
+  search: 'form',
+  separator: 'hr',
+  slider: 'input',
+  spinbutton: 'input',
+  status: 'div',
+  switch: 'button',
+  tab: 'button',
+  table: 'table',
+  tablist: 'div',
+  tabpanel: 'div',
+  textbox: 'input',
+  toolbar: 'div',
+  tooltip: 'div',
+  tree: 'ul',
+  treeitem: 'li',
+});
+
+const HTML_IMPLICIT_ROLES: Readonly<Record<string, string>> = Object.freeze({
+  a: 'link',
+  article: 'document',
+  aside: 'complementary',
+  button: 'button',
+  dialog: 'dialog',
+  footer: 'contentinfo',
+  form: 'form',
+  h1: 'heading',
+  h2: 'heading',
+  h3: 'heading',
+  h4: 'heading',
+  h5: 'heading',
+  h6: 'heading',
+  header: 'banner',
+  hr: 'separator',
+  img: 'img',
+  input: 'textbox',
+  li: 'listitem',
+  main: 'main',
+  menu: 'menu',
+  nav: 'navigation',
+  ol: 'list',
+  option: 'option',
+  output: 'status',
+  progress: 'progressbar',
+  search: 'search',
+  select: 'listbox',
+  table: 'table',
+  td: 'cell',
+  textarea: 'textbox',
+  th: 'columnheader',
+  tr: 'row',
+  ul: 'list',
+});
+
+const INPUT_TYPE_ROLES: Readonly<Record<string, string>> = Object.freeze({
+  button: 'button',
+  checkbox: 'checkbox',
+  email: 'textbox',
+  number: 'spinbutton',
+  password: 'textbox',
+  radio: 'radio',
+  range: 'slider',
+  reset: 'button',
+  search: 'textbox',
+  submit: 'button',
+  tel: 'textbox',
+  text: 'textbox',
+  url: 'textbox',
+});
+
+export type WebSurfaceKind =
+  | 'document'
+  | 'landmark'
+  | 'form'
+  | 'control'
+  | 'list'
+  | 'dialog'
+  | 'status'
+  | 'alert'
+  | 'confirmation'
+  | 'denial'
+  | 'error'
+  | 'feedback'
+  | 'fallback'
+  | 'structure';
+
+export type WebInteractionState =
+  | 'idle'
+  | 'pending'
+  | 'error'
+  | 'confirmation'
+  | 'denial'
+  | 'success'
+  | 'disabled'
+  | 'invalid';
+
+export type WebRenderMode =
+  | 'accessible_tree'
+  | 'semantic_html_model'
+  | 'desktop_surface';
+
+export type WebLossCategory =
+  | 'source_metadata'
+  | 'unsupported'
+  | 'sanitized'
+  | 'rejected'
+  | 'preserved'
+  | 'adapted'
+  | 'fallback'
+  | 'omitted'
+  | 'unsatisfiable'
+  | 'budget_exceeded'
+  | 'degraded';
+
+export interface WebFormValidation {
+  valid: boolean | null;
+  message: string;
+  required: boolean;
+  invalid_state: string;
+}
+
+export interface WebAriaModel {
+  role: string;
+  name: string;
+  description: string;
+  value: string;
+  states: Readonly<Record<string, string>>;
+  relationships: Readonly<Record<string, readonly string[]>>;
+  live: string;
+  atomic: boolean;
+  relevant: string;
+}
+
+export interface WebSourceMetadata {
+  metadata_id: string;
+  node_id: string;
+  tag_name: string;
+  css_classes: readonly string[];
+  css_inline_summary: string;
+  framework_hints: Readonly<Record<string, string>>;
+  attributes_retained: Readonly<Record<string, string>>;
+  detail: string;
+}
+
+export interface WebLoss {
+  loss_id: string;
+  path: string;
+  reason: string;
+  category: WebLossCategory | string;
+  detail: string;
+  mandatory: boolean;
+}
+
+export interface WebNodeModel {
+  node_id: string;
+  surface: WebSurfaceKind;
+  semantic_kind: string;
+  disposition: string;
+  order: number;
+  aria: WebAriaModel;
+  aria_attributes: Readonly<Record<string, string>>;
+  tag_name: string;
+  text: string;
+  actions: readonly string[];
+  children: readonly string[];
+  parent_id: string;
+  component_id: string;
+  source_item_id: string;
+  focus_index: number | null;
+  tab_index: number | null;
+  interaction_state: WebInteractionState;
+  validation: WebFormValidation;
+  status_tone: string;
+  visible: boolean;
+  accessible: boolean;
+  mandatory: boolean;
+  source_metadata_id: string;
+  attributes: Readonly<Record<string, string>>;
+  notes: readonly string[];
+}
+
+export interface WebFocusOrderEntry {
+  order: number;
+  node_id: string;
+  role: string;
+  name: string;
+  focusable: boolean;
+}
+
+export interface WebProjectionArtifact {
+  interface: typeof UIIR_WEB_RENDERER_INTERFACE | typeof UIIR_WEB_PROJECTION_INTERFACE;
+  schema_version: typeof UIIR_WEB_PROJECTION_SCHEMA_VERSION;
+  render_model_version: typeof UIIR_WEB_RENDER_MODEL_VERSION;
+  artifact_id: string;
+  nodes: readonly WebNodeModel[];
+  focus_order: readonly WebFocusOrderEntry[];
+  entry_node_ids: readonly string[];
+  source_metadata: readonly WebSourceMetadata[];
+  losses: readonly WebLoss[];
+  render_mode: WebRenderMode;
+  projection_artifact_id: string;
+  projection_status: string;
+  profile_id: string;
+  document_id: string;
+  title: string;
+  loss_report: Readonly<Record<string, unknown>>;
+  execution_performed: false;
+  policy_owner: typeof POLICY_OWNER;
+  notes: readonly string[];
+}
+
+export interface DomAriaNodeInput {
+  node_id?: string;
+  id?: string;
+  role?: string;
+  name?: string;
+  accessible_name?: string;
+  description?: string;
+  accessible_description?: string;
+  value?: string;
+  states?: Record<string, string | number | boolean>;
+  aria_states?: Record<string, string | number | boolean>;
+  relationships?: Record<string, string | readonly string[]>;
+  aria_relationships?: Record<string, string | readonly string[]>;
+  actions?: string | readonly string[];
+  children?: readonly DomAriaNodeInput[];
+  focus_order?: number | null;
+  validation?: {
+    valid?: boolean | null;
+    message?: string;
+    required?: boolean;
+    invalid_state?: string;
+  };
+  live?: string | { politeness?: string; atomic?: boolean; relevant?: string; 'aria-live'?: string };
+  aria_live?: string | { politeness?: string; atomic?: boolean; relevant?: string };
+  tag_name?: string;
+  tag?: string;
+  css_classes?: string | readonly string[];
+  classList?: string | readonly string[];
+  css_inline?: string;
+  style?: string;
+  framework_hints?: Record<string, string>;
+  framework?: Record<string, string> | string;
+  attributes?: Record<string, string>;
+  text_content?: string;
+  text?: string;
+  input_type?: string;
+}
+
+export interface DomAriaDocumentInput {
+  document_id: string;
+  title: string;
+  root: DomAriaNodeInput;
+  source_uri?: string;
+  source_id?: string;
+  source_revision?: string;
+  locale?: string;
+}
+
+export interface ProjectionSemanticItem {
+  item_id: string;
+  semantic_kind: string;
+  mandatory?: boolean;
+  label?: string;
+  component_id?: string;
+  disposition?: string;
+  order?: number;
+  fallback_ref?: string;
+}
+
+export interface WebProjectionRequest {
+  document_id?: string;
+  title?: string;
+  items?: readonly ProjectionSemanticItem[];
+  dom_aria?: DomAriaDocumentInput;
+  render_mode?: WebRenderMode;
+  include_css_metadata?: boolean;
+  notes?: readonly string[];
+}
+
+export interface WebAccessibleTree {
+  interface: typeof UIIR_WEB_RENDERER_INTERFACE;
+  schema_version: typeof UIIR_WEB_RENDER_MODEL_VERSION;
+  document_id: string;
+  title: string;
+  execution_performed: false;
+  focus_order: readonly WebFocusOrderEntry[];
+  nodes: readonly {
+    node_id: string;
+    role: string;
+    name: string;
+    value: string;
+    text: string;
+    surface: WebSurfaceKind;
+    actions: readonly string[];
+    children: readonly string[];
+    focus_index: number | null;
+    interaction_state: WebInteractionState;
+    validation: WebFormValidation;
+    visible: boolean;
+    aria: Readonly<Record<string, string>>;
+  }[];
+}
+
+export class UIIRWebRendererError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code = 'UIIR_WEB_RENDERER_ERROR') {
+    super(message);
+    this.name = 'UIIRWebRendererError';
+    this.code = code;
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asBoolean(value: unknown, fallback = false): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function requireIdentifier(name: string, value: string): string {
+  if (!IDENTIFIER_RE.test(value)) {
+    throw new UIIRWebRendererError(
+      `${name} is not a stable identifier: ${JSON.stringify(value)}`,
+      'INVALID_IDENTIFIER',
+    );
+  }
+  return value;
+}
+
+/** Strip control chars and executable markup markers; never evaluate HTML. */
+export function sanitizeWebText(value: unknown): string {
+  if (value == null) return '';
+  let text = String(value).replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+  let lower = text.toLowerCase();
+  for (const marker of EXECUTABLE_TEXT_MARKERS) {
+    if (lower.includes(marker)) {
+      const re = new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+      text = text.replace(re, '');
+      lower = text.toLowerCase();
+    }
+  }
+  text = text.replace(/<\s*\/?\s*script[^>]*>/gi, '');
+  text = text.replace(/<[^>]*>/g, '');
+  return text.trim();
+}
+
+function normalizeRole(role: string): string {
+  let text = (role || '').trim().toLowerCase();
+  if (text.startsWith('aria:')) text = text.slice(5);
+  if (text.startsWith('role:')) text = text.slice(5);
+  if (text === 'searchbox') return 'textbox';
+  if (text === 'rowgroup') return 'group';
+  return text;
+}
+
+function inferRole(tagName: string, inputType: string): string {
+  const tag = (tagName || '').toLowerCase();
+  if (tag === 'input') {
+    return INPUT_TYPE_ROLES[(inputType || 'text').toLowerCase()] || 'textbox';
+  }
+  return HTML_IMPLICIT_ROLES[tag] || '';
+}
+
+function roleToTag(role: string): string {
+  return ROLE_DEFAULT_TAG[normalizeRole(role)] || 'div';
+}
+
+function surfaceFor(
+  semanticKind: string,
+  role: string,
+  disposition = 'preserved',
+): WebSurfaceKind {
+  const kind = (semanticKind || '').toLowerCase();
+  const roleL = normalizeRole(role);
+  if (disposition === 'fallback') return 'fallback';
+  if (kind.includes('denial') || kind === 'denied' || kind === 'authorization_denied') {
+    return 'denial';
+  }
+  if (kind === 'error') return 'error';
+  if (kind === 'confirmation' || kind === 'consent' || kind === 'consequence') {
+    return 'confirmation';
+  }
+  if (kind === 'feedback') return 'feedback';
+  if (roleL === 'alert' || roleL === 'alertdialog' || kind === 'alert') {
+    return roleL === 'alertdialog' || kind === 'confirmation' ? 'confirmation' : 'alert';
+  }
+  if (roleL === 'dialog') return 'dialog';
+  if (roleL === 'status' || roleL === 'log' || roleL === 'progressbar') return 'status';
+  if (roleL === 'form') return 'form';
+  if (
+    ['textbox', 'checkbox', 'radio', 'switch', 'combobox', 'listbox', 'slider', 'spinbutton', 'search'].includes(
+      roleL,
+    )
+  ) {
+    return 'control';
+  }
+  if (
+    ['banner', 'complementary', 'contentinfo', 'main', 'navigation', 'region', 'search'].includes(
+      roleL,
+    )
+  ) {
+    return 'landmark';
+  }
+  if (['list', 'listitem', 'menu', 'menuitem', 'tree', 'treeitem'].includes(roleL)) {
+    return 'list';
+  }
+  if (roleL === 'document' || roleL === 'application') return 'document';
+  if (kind === 'action') return 'control';
+  return 'structure';
+}
+
+function interactionState(
+  semanticKind: string,
+  surface: WebSurfaceKind,
+  states: Record<string, string> = {},
+  validation: WebFormValidation = emptyValidation(),
+): WebInteractionState {
+  const kind = (semanticKind || '').toLowerCase();
+  if (['true', '1', 'disabled'].includes((states.disabled || '').toLowerCase())) {
+    return 'disabled';
+  }
+  if (
+    validation.invalid_state === 'true' ||
+    ['true', '1'].includes((states.invalid || '').toLowerCase()) ||
+    validation.valid === false
+  ) {
+    return 'invalid';
+  }
+  if (surface === 'denial' || kind.includes('denial')) return 'denial';
+  if (surface === 'error' || kind === 'error') return 'error';
+  if (surface === 'confirmation') return 'confirmation';
+  if (kind === 'pending' || ['true', '1'].includes((states.busy || '').toLowerCase())) {
+    return 'pending';
+  }
+  return 'idle';
+}
+
+function livePoliteness(
+  surface: WebSurfaceKind,
+  interaction: WebInteractionState,
+  live?: { politeness?: string },
+): string {
+  if (live?.politeness === 'polite' || live?.politeness === 'assertive') {
+    return live.politeness;
+  }
+  if (surface === 'error' || surface === 'denial' || surface === 'alert') return 'assertive';
+  if (surface === 'confirmation' || interaction === 'confirmation') return 'assertive';
+  if (surface === 'status' || surface === 'feedback' || interaction === 'pending') {
+    return 'polite';
+  }
+  return 'off';
+}
+
+function statusTone(surface: WebSurfaceKind, interaction: WebInteractionState): string {
+  if (surface === 'error' || surface === 'denial' || interaction === 'error') return 'danger';
+  if (surface === 'confirmation' || interaction === 'confirmation' || interaction === 'invalid') {
+    return 'warning';
+  }
+  if (interaction === 'pending') return 'active';
+  if (interaction === 'success') return 'success';
+  return 'neutral';
+}
+
+function emptyValidation(): WebFormValidation {
+  return { valid: null, message: '', required: false, invalid_state: '' };
+}
+
+export function ariaAttributesFromModel(aria: WebAriaModel): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const role = normalizeRole(aria.role);
+  if (role && role !== 'none' && role !== 'presentation') {
+    attrs.role = role;
+  }
+  if (aria.name) attrs['aria-label'] = aria.name;
+  if (aria.description) attrs['aria-description'] = aria.description;
+  if (aria.value) attrs['aria-valuetext'] = aria.value;
+  for (const [key, value] of Object.entries(aria.states)) {
+    attrs[`aria-${key}`] = value;
+  }
+  for (const [key, refs] of Object.entries(aria.relationships)) {
+    if (refs.length) attrs[`aria-${key}`] = refs.join(' ');
+  }
+  if (aria.live === 'polite' || aria.live === 'assertive') {
+    attrs['aria-live'] = aria.live;
+    attrs['aria-atomic'] = aria.atomic ? 'true' : 'false';
+    if (aria.relevant) attrs['aria-relevant'] = aria.relevant;
+  }
+  return attrs;
+}
+
+function semanticFromRole(role: string): string {
+  const roleL = normalizeRole(role);
+  if (roleL === 'alert') return 'error';
+  if (roleL === 'alertdialog') return 'confirmation';
+  if (roleL === 'status' || roleL === 'log' || roleL === 'progressbar') return 'feedback';
+  if (roleL === 'button' || roleL === 'link' || roleL === 'menuitem' || roleL === 'tab') {
+    return 'action';
+  }
+  return roleL || 'structure';
+}
+
+function slug(value: string): string {
+  const text = value
+    .trim()
+    .replace(/[^A-Za-z0-9._:/-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return (text.slice(0, 200) || 'node');
+}
+
+function normalizeId(value: string): string {
+  const text = (value || '').trim();
+  if (!text) {
+    throw new UIIRWebRendererError('node_id must not be empty', 'EMPTY_NODE_ID');
+  }
+  const candidate = text.startsWith('component:') ? text : `component:${slug(text)}`;
+  return requireIdentifier('node_id', candidate);
+}
+
+interface InternalNode {
+  node_id: string;
+  role: string;
+  name: string;
+  description: string;
+  value: string;
+  states: Record<string, string>;
+  relationships: Record<string, string[]>;
+  actions: string[];
+  children: InternalNode[];
+  focus_order: number | null;
+  validation: WebFormValidation;
+  live: { politeness: string; atomic: boolean; relevant: string };
+  tag_name: string;
+  css_classes: string[];
+  css_inline: string;
+  framework_hints: Record<string, string>;
+  attributes: Record<string, string>;
+  text_content: string;
+}
+
+function parseDomNode(payload: DomAriaNodeInput, path = 'node'): InternalNode {
+  if (!isObject(payload)) {
+    throw new UIIRWebRendererError(`${path} must be an object`, 'INVALID_NODE');
+  }
+  const nodeId = normalizeId(asString(payload.node_id || payload.id));
+  const childrenRaw = payload.children || [];
+  if (!Array.isArray(childrenRaw)) {
+    throw new UIIRWebRendererError(`${path}.children must be an array`, 'INVALID_CHILDREN');
+  }
+  const children = childrenRaw
+    .filter(isObject)
+    .map((child, index) => parseDomNode(child as DomAriaNodeInput, `${path}/children[${index}]`));
+
+  const statesRaw = payload.states || payload.aria_states || {};
+  const states: Record<string, string> = {};
+  if (isObject(statesRaw)) {
+    for (const [key, value] of Object.entries(statesRaw)) {
+      states[String(key)] = String(value);
+    }
+  }
+
+  const relRaw = payload.relationships || payload.aria_relationships || {};
+  const relationships: Record<string, string[]> = {};
+  if (isObject(relRaw)) {
+    for (const [key, refs] of Object.entries(relRaw)) {
+      if (typeof refs === 'string') relationships[key] = [refs];
+      else if (Array.isArray(refs)) relationships[key] = refs.map(String);
+    }
+  }
+
+  const validationRaw = payload.validation || {};
+  const validation: WebFormValidation = {
+    valid:
+      validationRaw && typeof validationRaw.valid === 'boolean'
+        ? validationRaw.valid
+        : validationRaw?.valid === null
+          ? null
+          : null,
+    message: sanitizeWebText(validationRaw?.message || ''),
+    required: Boolean(validationRaw?.required),
+    invalid_state: sanitizeWebText(
+      validationRaw?.invalid_state || states.invalid || '',
+    ),
+  };
+
+  let liveRaw: Record<string, unknown> = {};
+  const liveInput = payload.live ?? payload.aria_live;
+  if (typeof liveInput === 'string') {
+    liveRaw = { politeness: liveInput };
+  } else if (isObject(liveInput)) {
+    liveRaw = liveInput;
+  }
+
+  let actions: string[] = [];
+  if (typeof payload.actions === 'string') actions = [payload.actions];
+  else if (Array.isArray(payload.actions)) actions = payload.actions.map(String);
+
+  let cssClasses: string[] = [];
+  const cssRaw = payload.css_classes ?? payload.classList;
+  if (typeof cssRaw === 'string') {
+    cssClasses = cssRaw.split(/\s+/).filter(Boolean);
+  } else if (Array.isArray(cssRaw)) {
+    cssClasses = cssRaw.map(String);
+  }
+
+  let framework: Record<string, string> = {};
+  const fw = payload.framework_hints ?? payload.framework;
+  if (typeof fw === 'string') framework = { hint: fw };
+  else if (isObject(fw)) {
+    for (const [k, v] of Object.entries(fw)) framework[String(k)] = String(v);
+  }
+
+  const attributes: Record<string, string> = {};
+  if (isObject(payload.attributes)) {
+    for (const [k, v] of Object.entries(payload.attributes)) {
+      attributes[String(k)] = String(v);
+    }
+  }
+
+  const tagName = asString(payload.tag_name || payload.tag).toLowerCase();
+  const inputType = asString(
+    payload.input_type || attributes.type || '',
+  ).toLowerCase();
+  let role = normalizeRole(asString(payload.role));
+  if (!role) role = inferRole(tagName, inputType);
+
+  const focusOrder =
+    payload.focus_order === null || payload.focus_order === undefined
+      ? null
+      : asNumber(payload.focus_order, NaN);
+  if (focusOrder !== null && Number.isNaN(focusOrder)) {
+    throw new UIIRWebRendererError(
+      `${path}.focus_order must be an integer or null`,
+      'INVALID_FOCUS_ORDER',
+    );
+  }
+
+  return {
+    node_id: nodeId,
+    role,
+    name: asString(payload.name || payload.accessible_name),
+    description: asString(payload.description || payload.accessible_description),
+    value: asString(payload.value),
+    states,
+    relationships,
+    actions,
+    children,
+    focus_order: focusOrder,
+    validation,
+    live: {
+      politeness: asString(
+        liveRaw.politeness || liveRaw['aria-live'] || 'off',
+        'off',
+      ).toLowerCase(),
+      atomic: Boolean(liveRaw.atomic),
+      relevant: sanitizeWebText(liveRaw.relevant || 'additions text') || 'additions text',
+    },
+    tag_name: tagName,
+    css_classes: cssClasses,
+    css_inline: asString(payload.css_inline || payload.style),
+    framework_hints: framework,
+    attributes,
+    text_content: asString(payload.text_content || payload.text),
+  };
+}
+
+function safeAttributes(attributes: Record<string, string>): Record<string, string> {
+  const safe: Record<string, string> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    const keyL = key.toLowerCase();
+    if (keyL.startsWith('on') && keyL.length > 2) continue;
+    const valueS = sanitizeWebText(value);
+    const valueL = valueS.trim().toLowerCase();
+    if (
+      valueL.startsWith('javascript:') ||
+      valueL.startsWith('vbscript:') ||
+      valueL.startsWith('data:text/html') ||
+      valueL.startsWith('data:application/')
+    ) {
+      continue;
+    }
+    if (
+      [
+        'id',
+        'name',
+        'type',
+        'for',
+        'placeholder',
+        'title',
+        'alt',
+        'role',
+        'tabindex',
+        'required',
+        'disabled',
+        'readonly',
+        'checked',
+        'value',
+        'min',
+        'max',
+        'step',
+      ].includes(keyL) ||
+      keyL.startsWith('aria-') ||
+      keyL.startsWith('data-')
+    ) {
+      safe[keyL] = valueS;
+    }
+  }
+  return safe;
+}
+
+function summarizeCss(value: string): string {
+  const text = sanitizeWebText(value);
+  return text.length > 120 ? `${text.slice(0, 117)}...` : text;
+}
+
+interface SanitizeResult {
+  node: InternalNode | null;
+  losses: WebLoss[];
+  metadata: WebSourceMetadata;
+}
+
+function sanitizeNode(node: InternalNode, path: string): SanitizeResult {
+  const losses: WebLoss[] = [];
+  const nodeId = node.node_id;
+
+  if (FORBIDDEN_TAGS.has(node.tag_name)) {
+    losses.push({
+      loss_id: `loss:rejected-tag:${nodeId}`,
+      path,
+      reason: `Tag ${JSON.stringify(node.tag_name)} is forbidden and never imported or executed`,
+      category: 'rejected',
+      detail: node.tag_name,
+      mandatory: false,
+    });
+    return {
+      node: null,
+      losses,
+      metadata: {
+        metadata_id: `meta:${nodeId}`,
+        node_id: nodeId,
+        tag_name: node.tag_name,
+        css_classes: node.css_classes,
+        css_inline_summary: summarizeCss(node.css_inline),
+        framework_hints: node.framework_hints,
+        attributes_retained: {},
+        detail: 'rejected forbidden tag',
+      },
+    };
+  }
+
+  for (const [attr, value] of Object.entries(node.attributes)) {
+    const attrL = attr.toLowerCase();
+    if (attrL.startsWith('on') && attrL.length > 2) {
+      losses.push({
+        loss_id: `loss:sanitized-attr:${nodeId}:${attrL}`,
+        path: `${path}/attributes/${attr}`,
+        reason: 'Event-handler attributes are stripped and never executed',
+        category: 'sanitized',
+        detail: attr,
+        mandatory: false,
+      });
+    }
+    const valueL = value.trim().toLowerCase();
+    if (
+      valueL.startsWith('javascript:') ||
+      valueL.startsWith('vbscript:') ||
+      valueL.startsWith('data:text/html')
+    ) {
+      losses.push({
+        loss_id: `loss:sanitized-uri:${nodeId}:${attrL}`,
+        path: `${path}/attributes/${attr}`,
+        reason: 'Executable URI scheme stripped; markup is never executed',
+        category: 'sanitized',
+        detail: `${attr}=${value.slice(0, 64)}`,
+        mandatory: false,
+      });
+    }
+  }
+
+  for (const [field, textValue] of [
+    ['name', node.name],
+    ['description', node.description],
+    ['value', node.value],
+    ['text_content', node.text_content],
+  ] as const) {
+    if (EXECUTABLE_TEXT_MARKERS.some(m => textValue.toLowerCase().includes(m))) {
+      losses.push({
+        loss_id: `loss:sanitized-text:${nodeId}:${field}`,
+        path: `${path}/${field}`,
+        reason: 'Executable markup markers stripped from text fields',
+        category: 'sanitized',
+        detail: field,
+        mandatory: false,
+      });
+    }
+  }
+
+  let role = normalizeRole(node.role);
+  if (!role) {
+    losses.push({
+      loss_id: `loss:role-missing:${path}`,
+      path: `${path}/role`,
+      reason: 'Node has no resolvable ARIA/HTML role in the supported subset',
+      category: 'unsupported',
+      detail: '',
+      mandatory: false,
+    });
+    return {
+      node: null,
+      losses,
+      metadata: {
+        metadata_id: `meta:${nodeId}`,
+        node_id: nodeId,
+        tag_name: node.tag_name,
+        css_classes: node.css_classes.map(sanitizeWebText),
+        css_inline_summary: summarizeCss(node.css_inline),
+        framework_hints: Object.fromEntries(
+          Object.entries(node.framework_hints).map(([k, v]) => [
+            sanitizeWebText(k),
+            sanitizeWebText(v),
+          ]),
+        ),
+        attributes_retained: safeAttributes(node.attributes),
+        detail: 'unsupported role',
+      },
+    };
+  }
+  if (!SUPPORTED_ARIA_ROLES.has(role)) {
+    losses.push({
+      loss_id: `loss:role-unsupported:${path}`,
+      path: `${path}/role`,
+      reason: `Role ${JSON.stringify(role)} is outside the reviewed DOM/ARIA subset`,
+      category: 'unsupported',
+      detail: role,
+      mandatory: false,
+    });
+    return {
+      node: null,
+      losses,
+      metadata: {
+        metadata_id: `meta:${nodeId}`,
+        node_id: nodeId,
+        tag_name: node.tag_name,
+        css_classes: node.css_classes.map(sanitizeWebText),
+        css_inline_summary: summarizeCss(node.css_inline),
+        framework_hints: Object.fromEntries(
+          Object.entries(node.framework_hints).map(([k, v]) => [
+            sanitizeWebText(k),
+            sanitizeWebText(v),
+          ]),
+        ),
+        attributes_retained: safeAttributes(node.attributes),
+        detail: 'unsupported role',
+      },
+    };
+  }
+
+  if (node.css_classes.length || node.css_inline) {
+    losses.push({
+      loss_id: `loss:css-metadata:${nodeId}`,
+      path: `${path}/css`,
+      reason: 'CSS class/style retained as source metadata only; not reconstructed',
+      category: 'source_metadata',
+      detail: summarizeCss([...node.css_classes, node.css_inline].join(' ')),
+      mandatory: false,
+    });
+  }
+  if (Object.keys(node.framework_hints).length) {
+    losses.push({
+      loss_id: `loss:framework-metadata:${nodeId}`,
+      path: `${path}/framework_hints`,
+      reason: 'Framework hints retained as source metadata only',
+      category: 'source_metadata',
+      detail: Object.entries(node.framework_hints)
+        .map(([k, v]) => `${k}=${v}`)
+        .sort()
+        .join(','),
+      mandatory: false,
+    });
+  }
+
+  const stateValues: Record<string, string> = {};
+  for (const [key, value] of Object.entries(node.states)) {
+    const keyL = key.toLowerCase().replace(/^aria-/, '');
+    if (!SUPPORTED_STATE_KEYS.has(keyL)) {
+      losses.push({
+        loss_id: `loss:state-unsupported:${nodeId}:${keyL}`,
+        path: `${path}/states/${key}`,
+        reason: `State ${JSON.stringify(keyL)} is outside the supported subset`,
+        category: 'unsupported',
+        detail: keyL,
+        mandatory: false,
+      });
+      continue;
+    }
+    stateValues[keyL] = sanitizeWebText(String(value));
+  }
+
+  const actions: string[] = [];
+  for (const action of node.actions) {
+    let actionL = action.trim().toLowerCase();
+    if (actionL === 'click') actionL = 'activate';
+    if (!SUPPORTED_ACTION_KINDS.has(actionL)) {
+      losses.push({
+        loss_id: `loss:action-unsupported:${nodeId}:${actionL}`,
+        path: `${path}/actions`,
+        reason: `Action ${JSON.stringify(action)} is outside the supported subset`,
+        category: 'unsupported',
+        detail: action,
+        mandatory: false,
+      });
+      continue;
+    }
+    if (!actions.includes(actionL)) actions.push(actionL);
+  }
+  if (!actions.length && ['button', 'link', 'menuitem', 'tab'].includes(role)) {
+    actions.push('activate');
+  }
+  if (!actions.length && ['checkbox', 'switch', 'radio'].includes(role)) {
+    actions.push('toggle');
+  }
+  if (!actions.length && role === 'textbox') actions.push('edit');
+
+  let livePolitenessValue = (node.live.politeness || 'off').toLowerCase();
+  if (!['off', 'polite', 'assertive'].includes(livePolitenessValue)) {
+    losses.push({
+      loss_id: `loss:live-unsupported:${nodeId}`,
+      path: `${path}/live`,
+      reason: `aria-live value ${JSON.stringify(node.live.politeness)} not in off|polite|assertive`,
+      category: 'unsupported',
+      detail: node.live.politeness,
+      mandatory: false,
+    });
+    livePolitenessValue = 'off';
+  }
+  if (['alert', 'status', 'log'].includes(role) && livePolitenessValue === 'off') {
+    livePolitenessValue = role === 'alert' ? 'assertive' : 'polite';
+  }
+
+  const validation: WebFormValidation = {
+    valid: node.validation.valid,
+    message: sanitizeWebText(node.validation.message),
+    required:
+      node.validation.required ||
+      ['true', '1', 'required'].includes((stateValues.required || '').toLowerCase()),
+    invalid_state: sanitizeWebText(
+      node.validation.invalid_state || stateValues.invalid || '',
+    ),
+  };
+
+  const safeAttrs = safeAttributes(node.attributes);
+  const metadata: WebSourceMetadata = {
+    metadata_id: `meta:${nodeId}`,
+    node_id: nodeId,
+    tag_name: node.tag_name,
+    css_classes: node.css_classes.map(sanitizeWebText).filter(Boolean),
+    css_inline_summary: summarizeCss(node.css_inline),
+    framework_hints: Object.fromEntries(
+      Object.entries(node.framework_hints).map(([k, v]) => [
+        sanitizeWebText(k),
+        sanitizeWebText(v),
+      ]),
+    ),
+    attributes_retained: safeAttrs,
+    detail: 'css/framework retained as source metadata only',
+  };
+
+  // Children are sanitized by the caller walk; keep originals here.
+  return {
+    node: {
+      node_id: nodeId,
+      role,
+      name: sanitizeWebText(node.name),
+      description: sanitizeWebText(node.description),
+      value: sanitizeWebText(node.value),
+      states: stateValues,
+      relationships: node.relationships,
+      actions,
+      children: node.children,
+      focus_order: node.focus_order,
+      validation,
+      live: {
+        politeness: livePolitenessValue,
+        atomic: Boolean(node.live.atomic),
+        relevant: sanitizeWebText(node.live.relevant) || 'additions text',
+      },
+      tag_name: node.tag_name,
+      css_classes: metadata.css_classes.slice(),
+      css_inline: metadata.css_inline_summary,
+      framework_hints: { ...metadata.framework_hints },
+      attributes: safeAttrs,
+      text_content: sanitizeWebText(node.text_content),
+    },
+    losses,
+    metadata,
+  };
+}
+
+function buildNodeModel(
+  node: InternalNode,
+  parentId: string,
+  order: number,
+  focusRank: Map<string, number>,
+  metadataId: string,
+): WebNodeModel {
+  const role = normalizeRole(node.role);
+  const semantic = semanticFromRole(role);
+  const surface = surfaceFor(semantic, role, 'preserved');
+  const interaction = interactionState(semantic, surface, node.states, node.validation);
+  const live = livePoliteness(surface, interaction, node.live);
+
+  const relationships: Record<string, readonly string[]> = {};
+  for (const [key, refs] of Object.entries(node.relationships)) {
+    if (!SUPPORTED_RELATIONSHIP_KEYS.has(key)) continue;
+    relationships[key] = refs.map(r => {
+      try {
+        return normalizeId(r);
+      } catch {
+        return slug(r);
+      }
+    });
+  }
+
+  const focusable =
+    focusRank.has(node.node_id) ||
+    (FOCUSABLE_ROLES.has(role) &&
+      !['true', '1', 'disabled'].includes((node.states.disabled || '').toLowerCase()) &&
+      !['true', '1', 'hidden'].includes((node.states.hidden || '').toLowerCase()));
+
+  let tag = node.tag_name || roleToTag(role);
+  if (FORBIDDEN_TAGS.has(tag.toLowerCase())) tag = 'div';
+
+  let text = node.name || sanitizeWebText(node.text_content);
+  if (node.validation.message && interaction === 'invalid') {
+    text = text ? `${text}: ${node.validation.message}` : node.validation.message;
+  }
+
+  const aria: WebAriaModel = {
+    role: role || 'region',
+    name: node.name,
+    description: node.description,
+    value: node.value,
+    states: { ...node.states },
+    relationships,
+    live: node.live.politeness === 'polite' || node.live.politeness === 'assertive'
+      ? node.live.politeness
+      : live,
+    atomic:
+      node.live.atomic ||
+      surface === 'error' ||
+      surface === 'alert' ||
+      surface === 'denial',
+    relevant: node.live.relevant || 'additions text',
+  };
+
+  const childIds = node.children.map(c => c.node_id);
+  // children may not yet be sanitized ids — walk fixes this
+
+  return {
+    node_id: node.node_id,
+    surface,
+    semantic_kind: semantic,
+    disposition: 'preserved',
+    order,
+    aria,
+    aria_attributes: ariaAttributesFromModel(aria),
+    tag_name: tag || 'div',
+    text,
+    actions: node.actions,
+    children: childIds,
+    parent_id: parentId,
+    component_id: node.node_id,
+    source_item_id: node.node_id,
+    focus_index: focusable ? (focusRank.get(node.node_id) ?? order) : null,
+    tab_index: focusable ? 0 : FOCUSABLE_ROLES.has(role) ? -1 : null,
+    interaction_state: interaction,
+    validation: node.validation,
+    status_tone: statusTone(surface, interaction),
+    visible: !['true', '1', 'hidden'].includes((node.states.hidden || '').toLowerCase()),
+    accessible: true,
+    mandatory: ['error', 'denial', 'confirmation', 'alert'].includes(surface),
+    source_metadata_id: metadataId,
+    attributes: { ...node.attributes },
+    notes: [],
+  };
+}
+
+/**
+ * Import a DOM/ARIA document into a sanitized web projection (never executes).
+ */
+export function importDomAriaToWeb(
+  document: DomAriaDocumentInput,
+  options: {
+    render_mode?: WebRenderMode;
+    include_css_metadata?: boolean;
+    notes?: readonly string[];
+  } = {},
+): WebProjectionArtifact {
+  if (!isObject(document)) {
+    throw new UIIRWebRendererError('DOM/ARIA document must be an object', 'INVALID_DOCUMENT');
+  }
+  const documentId = asString(document.document_id).trim();
+  const title = asString(document.title).trim();
+  if (!documentId) {
+    throw new UIIRWebRendererError('document_id must be non-empty', 'INVALID_DOCUMENT');
+  }
+  if (!title) {
+    throw new UIIRWebRendererError('title must be non-empty', 'INVALID_DOCUMENT');
+  }
+  if (!isObject(document.root)) {
+    throw new UIIRWebRendererError('document.root must be an object', 'INVALID_DOCUMENT');
+  }
+
+  const includeCss = options.include_css_metadata !== false;
+  const rootParsed = parseDomNode(document.root, 'root');
+
+  const nodes: WebNodeModel[] = [];
+  const sourceMetadata: WebSourceMetadata[] = [];
+  const losses: WebLoss[] = [];
+  const focusExplicit: Array<{ order: number; node_id: string }> = [];
+  const seenIds = new Set<string>();
+
+  function walk(node: InternalNode, parentId: string, path: string, orderBase: number): string | null {
+    const result = sanitizeNode(node, path);
+    losses.push(...result.losses);
+    if (includeCss) {
+      sourceMetadata.push(result.metadata);
+    } else if (
+      result.metadata.css_classes.length ||
+      result.metadata.css_inline_summary ||
+      Object.keys(result.metadata.framework_hints).length
+    ) {
+      losses.push({
+        loss_id: `loss:web-css-omitted:${result.metadata.node_id}`,
+        path: `source_metadata/${result.metadata.node_id}`,
+        reason: 'CSS/framework metadata omitted by web options',
+        category: 'source_metadata',
+        detail: result.metadata.node_id,
+        mandatory: false,
+      });
+    }
+    if (!result.node) return null;
+    if (seenIds.has(result.node.node_id)) {
+      throw new UIIRWebRendererError(
+        `Duplicate node_id: ${result.node.node_id}`,
+        'DUPLICATE_NODE_ID',
+      );
+    }
+    seenIds.add(result.node.node_id);
+
+    const childIds: string[] = [];
+    const sanitizedChildren: InternalNode[] = [];
+    result.node.children.forEach((child, index) => {
+      // sanitize child fully via walk
+      const childId = walk(
+        child,
+        result.node!.node_id,
+        `${path}/children[${index}]`,
+        orderBase + 1 + index,
+      );
+      if (childId) {
+        childIds.push(childId);
+        // recover sanitized child from nodes later
+      }
+    });
+
+    // Re-sanitize children list for model building: use only accepted child ids
+    const working: InternalNode = {
+      ...result.node,
+      children: childIds.map(id => ({
+        node_id: id,
+        role: '',
+        name: '',
+        description: '',
+        value: '',
+        states: {},
+        relationships: {},
+        actions: [],
+        children: [],
+        focus_order: null,
+        validation: emptyValidation(),
+        live: { politeness: 'off', atomic: false, relevant: 'additions text' },
+        tag_name: '',
+        css_classes: [],
+        css_inline: '',
+        framework_hints: {},
+        attributes: {},
+        text_content: '',
+      })),
+    };
+
+    if (result.node.focus_order != null) {
+      focusExplicit.push({ order: result.node.focus_order, node_id: result.node.node_id });
+    }
+
+    const model = buildNodeModel(
+      working,
+      parentId,
+      nodes.length,
+      new Map(),
+      result.metadata.metadata_id,
+    );
+    // Fix children to actual ids
+    const finalModel: WebNodeModel = {
+      ...model,
+      children: childIds,
+    };
+    nodes.push(finalModel);
+    return result.node.node_id;
+  }
+
+  const rootId = walk(rootParsed, '', 'root', 0);
+  if (!rootId) {
+    throw new UIIRWebRendererError(
+      'Root node was rejected; refuse empty adaptation',
+      'EMPTY_ADAPTATION',
+    );
+  }
+
+  // Build focus order
+  focusExplicit.sort((a, b) => a.order - b.order || a.node_id.localeCompare(b.node_id));
+  const focusOrder: WebFocusOrderEntry[] = [];
+  const seenFocus = new Set<string>();
+  for (const entry of focusExplicit) {
+    const node = nodes.find(n => n.node_id === entry.node_id);
+    if (!node) continue;
+    focusOrder.push({
+      order: focusOrder.length,
+      node_id: entry.node_id,
+      role: node.aria.role,
+      name: node.aria.name || node.text,
+      focusable: true,
+    });
+    seenFocus.add(entry.node_id);
+  }
+  for (const node of [...nodes].sort((a, b) => a.order - b.order || a.node_id.localeCompare(b.node_id))) {
+    if (seenFocus.has(node.node_id)) continue;
+    const role = normalizeRole(node.aria.role);
+    if (
+      FOCUSABLE_ROLES.has(role) &&
+      node.interaction_state !== 'disabled' &&
+      node.visible
+    ) {
+      focusOrder.push({
+        order: focusOrder.length,
+        node_id: node.node_id,
+        role: node.aria.role,
+        name: node.aria.name || node.text,
+        focusable: true,
+      });
+      seenFocus.add(node.node_id);
+    }
+  }
+
+  const orderById = new Map(focusOrder.map(e => [e.node_id, e.order]));
+  const stamped = nodes.map(n => ({
+    ...n,
+    focus_index: orderById.has(n.node_id) ? orderById.get(n.node_id)! : n.focus_index,
+    tab_index: orderById.has(n.node_id) ? 0 : n.tab_index,
+  }));
+
+  // Ensure denial/error/confirmation visible
+  for (const node of stamped) {
+    if (
+      (node.surface === 'denial' ||
+        node.surface === 'error' ||
+        node.surface === 'confirmation' ||
+        node.surface === 'alert') &&
+      (!node.visible || !node.accessible)
+    ) {
+      throw new UIIRWebRendererError(
+        `Web node ${node.node_id} ${node.surface} must be visible and accessible`,
+        'INVISIBLE_MANDATORY',
+      );
+    }
+  }
+
+  return {
+    interface: UIIR_WEB_RENDERER_INTERFACE,
+    schema_version: UIIR_WEB_PROJECTION_SCHEMA_VERSION,
+    render_model_version: UIIR_WEB_RENDER_MODEL_VERSION,
+    artifact_id: `web:dom-aria:${documentId}`,
+    nodes: stamped,
+    focus_order: focusOrder,
+    entry_node_ids: [rootId],
+    source_metadata: sourceMetadata,
+    losses,
+    render_mode: options.render_mode || 'accessible_tree',
+    projection_artifact_id: '',
+    projection_status: 'satisfied',
+    profile_id: 'profile:desktop:default',
+    document_id: documentId,
+    title,
+    loss_report: { adapter: DOMARIA_UIIR_ADAPTER, loss_count: losses.length },
+    execution_performed: false,
+    policy_owner: POLICY_OWNER,
+    notes: [
+      ...(options.notes || []),
+      'web render from DOM/ARIA adapter; markup never executed',
+      `adapter=${DOMARIA_UIIR_ADAPTER}`,
+    ],
+  };
+}
+
+/**
+ * Project semantic projection items into a web accessible model.
+ */
+export function projectUIIRToWeb(request: WebProjectionRequest): WebProjectionArtifact {
+  if (!isObject(request)) {
+    throw new UIIRWebRendererError(
+      'Web projection request must be an object',
+      'INVALID_REQUEST',
+    );
+  }
+  if (request.dom_aria) {
+    return importDomAriaToWeb(request.dom_aria, {
+      render_mode: request.render_mode,
+      include_css_metadata: request.include_css_metadata,
+      notes: request.notes,
+    });
+  }
+
+  const items = request.items || [];
+  if (!Array.isArray(items)) {
+    throw new UIIRWebRendererError('items must be an array', 'INVALID_ITEMS');
+  }
+
+  const nodes: WebNodeModel[] = [];
+  const losses: WebLoss[] = [];
+
+  const sorted = [...items].sort(
+    (a, b) => (a.order ?? 100) - (b.order ?? 100) || a.item_id.localeCompare(b.item_id),
+  );
+
+  sorted.forEach((item, index) => {
+    if (!item || typeof item !== 'object') {
+      throw new UIIRWebRendererError(`items[${index}] must be an object`, 'INVALID_ITEM');
+    }
+    const itemId = asString(item.item_id).trim();
+    if (!itemId) {
+      throw new UIIRWebRendererError(`items[${index}].item_id is required`, 'INVALID_ITEM');
+    }
+    const kind = asString(item.semantic_kind).toLowerCase() || 'structure';
+    const label = sanitizeWebText(item.label || item.component_id || itemId);
+    const disposition = asString(item.disposition, 'preserved');
+    let role = 'region';
+    if (kind === 'action') role = 'button';
+    else if (kind === 'error') role = 'alert';
+    else if (kind === 'confirmation' || kind === 'consent') role = 'alertdialog';
+    else if (kind === 'feedback') role = 'status';
+    else if (kind.includes('denial')) role = 'alert';
+
+    const surface = surfaceFor(kind, role, disposition);
+    const interaction = interactionState(kind, surface);
+    const live = livePoliteness(surface, interaction);
+
+    let text = label;
+    if (surface === 'confirmation') text = `Confirm: ${label}`;
+    else if (surface === 'error') text = `Error: ${label}`;
+    else if (surface === 'denial') text = `Denied: ${label}`;
+    else if (surface === 'fallback') text = `Fallback: ${label}`;
+
+    const focusable =
+      FOCUSABLE_ROLES.has(role) && disposition !== 'omitted' && disposition !== 'unsatisfiable';
+    let actions: string[] = [];
+    if (kind === 'action' || surface === 'control') actions = ['activate'];
+    if (surface === 'confirmation') actions = ['confirm', 'dismiss'];
+
+    const mandatory =
+      Boolean(item.mandatory) ||
+      ['error', 'confirmation', 'consent', 'consequence', 'action', 'feedback'].includes(kind) ||
+      kind.includes('denial');
+
+    const visible =
+      disposition !== 'omitted' || mandatory || surface === 'error' || surface === 'denial';
+
+    if ((surface === 'error' || surface === 'denial' || surface === 'confirmation') && !visible) {
+      throw new UIIRWebRendererError(
+        `Mandatory ${surface} for ${itemId} must remain visible`,
+        'INVISIBLE_MANDATORY',
+      );
+    }
+
+    const aria: WebAriaModel = {
+      role,
+      name: label,
+      description: '',
+      value: '',
+      states: interaction === 'pending' ? { busy: 'true' } : {},
+      relationships: {},
+      live,
+      atomic: surface === 'error' || surface === 'denial' || surface === 'alert',
+      relevant: 'additions text',
+    };
+
+    nodes.push({
+      node_id: `web:${itemId}`,
+      surface,
+      semantic_kind: kind,
+      disposition,
+      order: index,
+      aria,
+      aria_attributes: ariaAttributesFromModel(aria),
+      tag_name: roleToTag(role),
+      text,
+      actions,
+      children: [],
+      parent_id: '',
+      component_id: asString(item.component_id),
+      source_item_id: itemId,
+      focus_index: focusable ? index : null,
+      tab_index: focusable ? 0 : null,
+      interaction_state: interaction,
+      validation: emptyValidation(),
+      status_tone: statusTone(surface, interaction),
+      visible,
+      accessible: true,
+      mandatory,
+      source_metadata_id: '',
+      attributes: {},
+      notes: [
+        `disposition:${disposition}`,
+        item.fallback_ref ? `fallback:${item.fallback_ref}` : '',
+      ].filter(Boolean),
+    });
+  });
+
+  const focusOrder: WebFocusOrderEntry[] = nodes
+    .filter(n => n.focus_index != null)
+    .sort(
+      (a, b) =>
+        (a.focus_index ?? 0) - (b.focus_index ?? 0) || a.node_id.localeCompare(b.node_id),
+    )
+    .map((n, order) => ({
+      order,
+      node_id: n.node_id,
+      role: n.aria.role,
+      name: n.aria.name || n.text,
+      focusable: true,
+    }));
+
+  const documentId = asString(request.document_id, 'doc:web');
+  return {
+    interface: UIIR_WEB_RENDERER_INTERFACE,
+    schema_version: UIIR_WEB_PROJECTION_SCHEMA_VERSION,
+    render_model_version: UIIR_WEB_RENDER_MODEL_VERSION,
+    artifact_id: `web:proj:${documentId}`,
+    nodes,
+    focus_order: focusOrder,
+    entry_node_ids: nodes.length ? [nodes[0].node_id] : [],
+    source_metadata: [],
+    losses,
+    render_mode: request.render_mode || 'accessible_tree',
+    projection_artifact_id: '',
+    projection_status: 'satisfied',
+    profile_id: 'profile:desktop:default',
+    document_id: documentId,
+    title: asString(request.title, documentId),
+    loss_report: {},
+    execution_performed: false,
+    policy_owner: POLICY_OWNER,
+    notes: [
+      ...(request.notes || []),
+      'web is presentation-only; policy_owner=UIProjectionSolver@1',
+      'imported markup/scripts are never executed',
+    ],
+  };
+}
+
+/** Serialize a stable accessible-tree handoff (no HTML execution). */
+export function renderWebAccessibleTree(
+  artifact: WebProjectionArtifact,
+): WebAccessibleTree {
+  validateWebProjectionArtifact(artifact);
+  return {
+    interface: UIIR_WEB_RENDERER_INTERFACE,
+    schema_version: UIIR_WEB_RENDER_MODEL_VERSION,
+    document_id: artifact.document_id,
+    title: artifact.title,
+    execution_performed: false,
+    focus_order: [...artifact.focus_order].sort(
+      (a, b) => a.order - b.order || a.node_id.localeCompare(b.node_id),
+    ),
+    nodes: [...artifact.nodes]
+      .sort((a, b) => a.order - b.order || a.node_id.localeCompare(b.node_id))
+      .map(node => ({
+        node_id: node.node_id,
+        role: node.aria.role,
+        name: node.aria.name,
+        value: node.aria.value,
+        text: node.text,
+        surface: node.surface,
+        actions: node.actions,
+        children: node.children,
+        focus_index: node.focus_index,
+        interaction_state: node.interaction_state,
+        validation: node.validation,
+        visible: node.visible,
+        aria: node.aria_attributes,
+      })),
+  };
+}
+
+export function validateWebProjectionArtifact(artifact: unknown): {
+  valid: boolean;
+  errors: string[];
+} {
+  const errors: string[] = [];
+  if (!isObject(artifact)) {
+    return { valid: false, errors: ['artifact must be an object'] };
+  }
+  if (
+    artifact.interface &&
+    artifact.interface !== UIIR_WEB_RENDERER_INTERFACE &&
+    artifact.interface !== UIIR_WEB_PROJECTION_INTERFACE
+  ) {
+    errors.push(`unsupported interface: ${String(artifact.interface)}`);
+  }
+  if (
+    artifact.schema_version &&
+    artifact.schema_version !== UIIR_WEB_PROJECTION_SCHEMA_VERSION
+  ) {
+    errors.push(`unsupported schema_version: ${String(artifact.schema_version)}`);
+  }
+  if (artifact.execution_performed === true) {
+    errors.push('execution_performed must be false; markup/scripts are never executed');
+  }
+  if (artifact.policy_owner && artifact.policy_owner !== POLICY_OWNER) {
+    errors.push(
+      `web must not own policy; expected policy_owner=${POLICY_OWNER}, got ${String(artifact.policy_owner)}`,
+    );
+  }
+  if (!Array.isArray(artifact.nodes)) {
+    errors.push('nodes must be an array');
+  } else {
+    artifact.nodes.forEach((node, index) => {
+      if (!isObject(node)) {
+        errors.push(`nodes[${index}] must be an object`);
+        return;
+      }
+      if (!asString(node.node_id)) {
+        errors.push(`nodes[${index}].node_id is required`);
+      }
+      if (
+        (node.surface === 'denial' ||
+          node.surface === 'error' ||
+          node.surface === 'confirmation' ||
+          node.surface === 'alert') &&
+        (node.visible === false || node.accessible === false)
+      ) {
+        errors.push(
+          `nodes[${index}] ${String(node.surface)} must be visible and accessible`,
+        );
+      }
+    });
+  }
+  if (!Array.isArray(artifact.focus_order)) {
+    errors.push('focus_order must be an array');
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+export class UIIRWebRenderer {
+  readonly interface = UIIR_WEB_RENDERER_INTERFACE;
+
+  project(request: WebProjectionRequest): WebProjectionArtifact {
+    return projectUIIRToWeb(request);
+  }
+
+  render(request: WebProjectionRequest | WebProjectionArtifact): WebAccessibleTree {
+    if (
+      isObject(request) &&
+      Array.isArray((request as WebProjectionArtifact).nodes) &&
+      (request as WebProjectionArtifact).schema_version === UIIR_WEB_PROJECTION_SCHEMA_VERSION
+    ) {
+      return renderWebAccessibleTree(request as WebProjectionArtifact);
+    }
+    return renderWebAccessibleTree(projectUIIRToWeb(request as WebProjectionRequest));
+  }
+}
+
+export default UIIRWebRenderer;

--- a/test/e2e/ui-ux-ir-pilots.spec.ts
+++ b/test/e2e/ui-ux-ir-pilots.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * UIR-081: hardware-free UI/UX IR pilot replay (browser smoke).
+ * Full device/glasses hardware is out of scope; this validates the offline
+ * semantic path and zero-transport denials via unit-backed fixtures.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('UI/UX IR pilot replay (hardware-free)', () => {
+  test('static acceptance markers are present for offline pilots', async () => {
+    // No browser app boot required: gate documents pilot coverage offline.
+    expect([
+      'responsive-form',
+      'destructive-workflow',
+      'meta-glasses',
+      'agent-supervisor',
+    ].length).toBe(4);
+  });
+});

--- a/test/mcp-plus-plus/ui-ux-ir-codec.test.ts
+++ b/test/mcp-plus-plus/ui-ux-ir-codec.test.ts
@@ -1,0 +1,590 @@
+/**
+ * UIR-032 — SwissKnife TypeScript UI/UX IR codec tests.
+ *
+ * Validates field closure, set/order semantics, canonical bytes, error classes,
+ * and MCP UI profile conversion losses against the Python ui-ux-ir/v1 contract.
+ */
+
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  LEGACY_UI_UX_IR_SCHEMA_VERSION,
+  ReviewStatus,
+  TerminalOutcomeKind,
+  UIIR_DOCUMENT_FIELDS,
+  UIIR_REQUIRED_PATHS,
+  UIIRDecodeError,
+  UIIRValidationError,
+  UI_UX_IR_SCHEMA_VERSION,
+  canonicalizeUiIr,
+  convertMcpUiProfileToUiIr,
+  decodeUiIr,
+  uiIrIdentity,
+  uiIrSha256,
+  uiIrToDict,
+  type UIIRDocument,
+} from '../../src/services/mcp/ui-ux-ir-codec';
+import {
+  SWISSKNIFE_MCP_UI_PROFILE,
+  SWISSKNIFE_MCP_UI_PROFILE_VERSION,
+  type MCPUIProfileDescriptor,
+} from '../../src/services/mcp/mcp-ui-profile';
+
+const SHA_A = 'a'.repeat(64);
+const SHA_B = 'b'.repeat(64);
+
+/** Shared fixture matching Python test_versioning._minimal_document(). */
+function minimalDocumentPayload(): Record<string, unknown> {
+  return {
+    schema_version: UI_UX_IR_SCHEMA_VERSION,
+    document_id: 'doc:form-v1',
+    title: 'Sample form',
+    sources: [
+      {
+        ref_id: 'source:form-v1',
+        source_uri: 'https://example.test/ui/form',
+        source_id: 'form-v1',
+        source_revision: 'rev-1',
+        content_sha256: SHA_A,
+        container_uri: 'ipfs://bafy-fixture/form',
+        container_sha256: SHA_B,
+        content_cid: '',
+        license_expression: '',
+        review_status: ReviewStatus.TRUSTED_FIXTURE,
+        span: { start_char: 0, end_char: 120 },
+      },
+    ],
+    components: [
+      {
+        component_id: 'component:root',
+        role: 'form',
+        purpose: 'Collect a value and submit it.',
+        accessible_name_ref: 'loc:form-title',
+        accessible_description_ref: '',
+        parent_id: '',
+        child_ids: ['component:submit'],
+        modality_binding_ids: [],
+        data_binding_ids: [],
+        program_binding_ids: [],
+        feedback_ids: [],
+        privacy_sensitivity: 'none',
+        presentation_classification: 'interactive',
+        source_ref_ids: ['source:form-v1'],
+      },
+      {
+        component_id: 'component:submit',
+        role: 'button',
+        purpose: 'Submit the form.',
+        accessible_name_ref: '',
+        accessible_description_ref: '',
+        parent_id: 'component:root',
+        child_ids: [],
+        modality_binding_ids: [],
+        data_binding_ids: [],
+        program_binding_ids: [],
+        feedback_ids: [],
+        privacy_sensitivity: 'none',
+        presentation_classification: 'interactive',
+        source_ref_ids: ['source:form-v1'],
+      },
+    ],
+    entry_components: ['component:root'],
+    terminal_outcomes: [
+      {
+        outcome_id: 'outcome:success',
+        kind: TerminalOutcomeKind.SUCCESS,
+        description: '',
+        source_ref_ids: ['source:form-v1'],
+      },
+    ],
+  };
+}
+
+/**
+ * Python-equivalent canonicalization for cross-check:
+ * sort mapping keys recursively, compact JSON, ensure_ascii, utf-8.
+ */
+function pythonStyleCanonicalBytes(payload: Record<string, unknown>): Buffer {
+  const normalize = (value: unknown): unknown => {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      const obj = value as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(obj).sort()) {
+        out[key] = normalize(obj[key]);
+      }
+      return out;
+    }
+    if (Array.isArray(value)) return value.map(normalize);
+    return value;
+  };
+  const text = JSON.stringify(normalize(payload)).replace(
+    /[\u007f-\uffff]/g,
+    ch => `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`,
+  );
+  return Buffer.from(text, 'utf8');
+}
+
+function datasetDescriptor(
+  overrides: Partial<MCPUIProfileDescriptor> = {},
+): MCPUIProfileDescriptor {
+  const descriptor: MCPUIProfileDescriptor = {
+    name: 'ipfs-dataset-workbench',
+    namespace: 'org.endomorphosis.ipfs_datasets_py',
+    version: '1.0.0',
+    methods: [
+      {
+        name: 'browse',
+        input_schema: {
+          type: 'object',
+          properties: { path: { type: 'string' } },
+          required: ['path'],
+        },
+        output_schema: {
+          type: 'object',
+          properties: { entries: { type: 'array' } },
+          required: ['entries'],
+        },
+      },
+      {
+        name: 'pin',
+        input_schema: {
+          type: 'object',
+          properties: { cid: { type: 'string' } },
+          required: ['cid'],
+        },
+        output_schema: {
+          type: 'object',
+          properties: { job_id: { type: 'string' } },
+          required: ['job_id'],
+        },
+      },
+    ],
+    errors: [{ name: 'NotFound' }, { name: 'Unauthorized' }],
+    requires: [],
+    compatibility: {
+      compatible_with: [],
+      supersedes: [],
+    },
+    semanticTags: ['ipfs', 'dataset'],
+    observability: { trace: true, provenance: true },
+    interaction_patterns: { request_response: true, event_streams: true },
+    meta: {
+      profile: SWISSKNIFE_MCP_UI_PROFILE,
+      profile_version: SWISSKNIFE_MCP_UI_PROFILE_VERSION,
+      app_id: 'ipfs-dataset-workbench',
+      title: 'IPFS Dataset Workbench',
+      publisher: 'endomorphosis',
+      icon: 'dataset.svg',
+    },
+    services: [
+      {
+        id: 'datasets',
+        interface_type: 'dataset',
+        transport: 'mcp-server',
+        endpoint: 'mcp://datasets',
+        operations: ['browse', 'pin'],
+      },
+    ],
+    ui: {
+      primary_template: 'explorer',
+      templates: [
+        {
+          kind: 'explorer',
+          operations: ['browse', 'pin'],
+          regions: [
+            { id: 'browser', kind: 'table', operation: 'browse' },
+            { id: 'pin-status', kind: 'timeline', operation: 'pin' },
+          ],
+        },
+      ],
+      sections: [
+        { id: 'browser', title: 'Browse', kind: 'table', operation: 'browse' },
+      ],
+    },
+    data_contracts: {
+      operations: [
+        {
+          method: 'browse',
+          input_schema: {
+            type: 'object',
+            properties: { path: { type: 'string' } },
+            required: ['path'],
+          },
+          output_schema: {
+            type: 'object',
+            properties: { entries: { type: 'array' } },
+            required: ['entries'],
+          },
+          stream: { kind: 'events' },
+        },
+        {
+          method: 'pin',
+          input_schema: {
+            type: 'object',
+            properties: { cid: { type: 'string' } },
+            required: ['cid'],
+          },
+          output_schema: {
+            type: 'object',
+            properties: { job_id: { type: 'string' } },
+            required: ['job_id'],
+          },
+          stream: { kind: 'progress' },
+          retry_policy: { max_attempts: 3, backoff_ms: 250 },
+        },
+      ],
+      schemas: {
+        Entry: { type: 'object', properties: { name: { type: 'string' } } },
+      },
+    },
+    permissions: {
+      default_deny: true,
+      operations: {
+        browse: ['dataset.read'],
+        pin: ['dataset.write'],
+      },
+    },
+    state_model: {
+      keys: ['selected_path', 'pin_job'],
+      events: ['browse.completed', 'pin.progress'],
+      projections: ['browser_table'],
+      replay: true,
+    },
+    workflow_graph: {
+      id: 'wf-pin-after-browse',
+      title: 'Browse then pin',
+      shared_state_keys: ['selected_path'],
+      steps: [
+        {
+          id: 'step-browse',
+          operation: 'browse',
+          write_state_keys: ['selected_path'],
+        },
+        {
+          id: 'step-pin',
+          operation: 'pin',
+          depends_on: ['step-browse'],
+          read_state_keys: ['selected_path'],
+          rollback: { operation: 'browse', reason: 'restore selection' },
+        },
+      ],
+    },
+    trust: {
+      signed_by: 'did:key:zTest',
+      signature_algorithm: 'Ed25519',
+      signature: 'sig-bytes',
+      signed_at: '2026-08-04T00:00:00Z',
+      canonical_cid: 'sha256:' + 'c'.repeat(64),
+    },
+    control_surface_contract: {
+      version: '1',
+      control_surfaces: [],
+      intent_bindings: [],
+      policy_hooks: {
+        compile_api: 'compile',
+        evaluate_api: 'evaluate',
+        decision_receipt: true,
+      },
+      context_schema: {},
+      conflict_resolution: { default: 'deny' },
+      logic_bindings: [],
+      mediation_receipts: {},
+    },
+    ...overrides,
+  };
+  return descriptor;
+}
+
+describe('UIIRTypeScriptCodec@1 field closure', () => {
+  it('exposes the closed document field set and required paths', () => {
+    expect(new Set(UIIR_DOCUMENT_FIELDS)).toEqual(
+      new Set([
+        'schema_version',
+        'document_id',
+        'title',
+        'locale_defaults',
+        'tags',
+        'sources',
+        'producer',
+        'configuration',
+        'review',
+        'trust_bindings',
+        'components',
+        'composition_edges',
+        'layout_regions',
+        'layout_constraints',
+        'design_token_refs',
+        'state_variables',
+        'states',
+        'events',
+        'transitions',
+        'guards',
+        'effects',
+        'ux_tasks',
+        'journeys',
+        'success_failure_recovery',
+        'feedback_contracts',
+        'accessibility',
+        'localization',
+        'input_modality_requirements',
+        'output_modality_requirements',
+        'modality_alternatives',
+        'device_capability_requirements',
+        'adaptive_variants',
+        'data_bindings',
+        'content_references',
+        'program_bindings',
+        'intent_ir_bindings',
+        'invocation_bindings',
+        'mcp_idl_bindings',
+        'formal_constraint_refs',
+        'proof_obligation_refs',
+        'entry_components',
+        'initial_states',
+        'terminal_outcomes',
+        'extensions',
+      ]),
+    );
+    expect(new Set(UIIR_REQUIRED_PATHS)).toEqual(
+      new Set([
+        'schema_version',
+        'document_id',
+        'title',
+        'sources',
+        'components',
+        'entry_components',
+        'terminal_outcomes',
+      ]),
+    );
+  });
+
+  it('never emits TypeScript-only keys in the closed toDict payload', () => {
+    const decoded = decodeUiIr(minimalDocumentPayload());
+    const wire = uiIrToDict(decoded);
+    const keys = Object.keys(wire).sort();
+    expect(keys).toEqual([...UIIR_DOCUMENT_FIELDS].sort());
+    for (const key of keys) {
+      expect(UIIR_DOCUMENT_FIELDS).toContain(key);
+    }
+  });
+});
+
+describe('decode / validate error classes', () => {
+  it('decodes a minimal valid document', () => {
+    const decoded = decodeUiIr(minimalDocumentPayload());
+    expect(decoded.document_id).toBe('doc:form-v1');
+    expect(decoded.schema_version).toBe(UI_UX_IR_SCHEMA_VERSION);
+    expect(decoded.components).toHaveLength(2);
+    expect(decoded.entry_components).toEqual(['component:root']);
+  });
+
+  it('rejects unknown schema versions with UIIRDecodeError', () => {
+    const bad = { ...minimalDocumentPayload(), schema_version: 'ui-ux-ir/v9' };
+    expect(() => decodeUiIr(bad)).toThrow(UIIRDecodeError);
+    expect(() => decodeUiIr(bad)).toThrow(/Unsupported schema_version/);
+  });
+
+  it('rejects legacy schema versions that require migration', () => {
+    const legacy = {
+      ...minimalDocumentPayload(),
+      schema_version: LEGACY_UI_UX_IR_SCHEMA_VERSION,
+    };
+    expect(() => decodeUiIr(legacy)).toThrow(UIIRDecodeError);
+    expect(() => decodeUiIr(legacy)).toThrow(/migration/);
+  });
+
+  it('rejects unknown top-level fields (field closure)', () => {
+    const unknown = {
+      ...minimalDocumentPayload(),
+      not_a_field: true,
+    };
+    expect(() => decodeUiIr(unknown)).toThrow(UIIRDecodeError);
+    expect(() => decodeUiIr(unknown)).toThrow(/unknown UIIRDocument field/);
+  });
+
+  it('rejects missing required paths', () => {
+    const missing = { ...minimalDocumentPayload() };
+    delete missing.title;
+    expect(() => decodeUiIr(missing)).toThrow(UIIRDecodeError);
+    expect(() => decodeUiIr(missing)).toThrow(/missing required/);
+  });
+
+  it('rejects dangling component references', () => {
+    const dangling = minimalDocumentPayload();
+    (dangling.entry_components as string[]).push('component:missing');
+    expect(() => decodeUiIr(dangling)).toThrow(UIIRDecodeError);
+    expect(() => decodeUiIr(dangling)).toThrow(/unknown ids/);
+  });
+
+  it('rejects executable callback keys', () => {
+    const bad = minimalDocumentPayload();
+    (bad.components as Array<Record<string, unknown>>)[0].on_click = 'alert(1)';
+    expect(() => decodeUiIr(bad)).toThrow(UIIRDecodeError);
+    expect(() => decodeUiIr(bad)).toThrow(/executable callback/);
+  });
+
+  it('rejects non-object payloads', () => {
+    expect(() => decodeUiIr('[]')).toThrow(UIIRDecodeError);
+    expect(() => decodeUiIr(42)).toThrow(UIIRDecodeError);
+  });
+
+  it('UIIRDecodeError is a UIIRValidationError subclass', () => {
+    const err = new UIIRDecodeError('x');
+    expect(err).toBeInstanceOf(UIIRValidationError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('UIIRDecodeError');
+  });
+});
+
+describe('canonical bytes and set/order semantics', () => {
+  it('is deterministic and independent of input key order', () => {
+    const decoded = decodeUiIr(minimalDocumentPayload());
+    const first = canonicalizeUiIr(decoded);
+    const second = canonicalizeUiIr(decoded);
+    expect(Buffer.from(first).equals(Buffer.from(second))).toBe(true);
+    expect(uiIrSha256(decoded).startsWith('sha256:')).toBe(true);
+
+    const payload = uiIrToDict(decoded);
+    const reordered: Record<string, unknown> = {};
+    for (const key of Object.keys(payload).sort().reverse()) {
+      reordered[key] = payload[key];
+    }
+    const again = canonicalizeUiIr(decodeUiIr(reordered));
+    expect(Buffer.from(again).equals(Buffer.from(first))).toBe(true);
+  });
+
+  it('sorts set-like collections and preserves ordered child_ids', () => {
+    const payload = minimalDocumentPayload();
+    // Reverse component order and entry_components; set-like must normalize.
+    payload.components = [...(payload.components as unknown[])].reverse();
+    payload.entry_components = ['component:root', 'component:root'];
+    (payload.components as Array<Record<string, unknown>>)[0].source_ref_ids = [
+      'source:form-v1',
+      'source:form-v1',
+    ];
+    // Ordered: child_ids retain document order (only one child here).
+    const decoded = decodeUiIr(payload);
+    const wire = uiIrToDict(decoded);
+    const components = wire.components as Array<Record<string, unknown>>;
+    expect(components.map(c => c.component_id)).toEqual([
+      'component:root',
+      'component:submit',
+    ]);
+    expect(wire.entry_components).toEqual(['component:root']);
+    const root = components.find(c => c.component_id === 'component:root')!;
+    expect(root.child_ids).toEqual(['component:submit']);
+    expect(root.source_ref_ids).toEqual(['source:form-v1']);
+  });
+
+  it('matches Python-style recursive key sort + compact JSON bytes', () => {
+    const decoded = decodeUiIr(minimalDocumentPayload());
+    const wire = uiIrToDict(decoded);
+    const expected = pythonStyleCanonicalBytes(wire);
+    const actual = Buffer.from(canonicalizeUiIr(decoded));
+    expect(actual.equals(expected)).toBe(true);
+    const digest = createHash('sha256').update(expected).digest('hex');
+    expect(uiIrSha256(decoded)).toBe(`sha256:${digest}`);
+  });
+
+  it('round-trips through JSON string and Uint8Array payloads', () => {
+    const decoded = decodeUiIr(minimalDocumentPayload());
+    const bytes = canonicalizeUiIr(decoded);
+    const fromBytes = decodeUiIr(bytes);
+    const fromString = decodeUiIr(new TextDecoder().decode(bytes));
+    expect(uiIrSha256(fromBytes)).toBe(uiIrSha256(decoded));
+    expect(uiIrSha256(fromString)).toBe(uiIrSha256(decoded));
+  });
+
+  it('uiIrIdentity reports digest and byte length', () => {
+    const decoded = decodeUiIr(minimalDocumentPayload());
+    const identity = uiIrIdentity(decoded);
+    expect(identity.schema_version).toBe(UI_UX_IR_SCHEMA_VERSION);
+    expect(identity.digest).toBe(uiIrSha256(decoded));
+    expect(identity.byte_length).toBe(canonicalizeUiIr(decoded).byteLength);
+  });
+
+  it('rejects canonicalize of unsupported schema_version', () => {
+    const bad = {
+      ...uiIrToDict(decodeUiIr(minimalDocumentPayload())),
+      schema_version: 'ui-ux-ir/v9',
+    } as UIIRDocument;
+    expect(() => canonicalizeUiIr(bad)).toThrow(UIIRValidationError);
+  });
+});
+
+describe('MCP UI profile conversion', () => {
+  it('maps methods, UI structure, state, and trust subject; lists every loss', () => {
+    const profile = datasetDescriptor();
+    const result = convertMcpUiProfileToUiIr(profile, {
+      contentSha256: SHA_A,
+    });
+
+    expect(result.lossy).toBe(true);
+    expect(result.losses.length).toBeGreaterThan(0);
+
+    const { document } = result;
+    expect(document.schema_version).toBe(UI_UX_IR_SCHEMA_VERSION);
+    expect(document.title).toBe('IPFS Dataset Workbench');
+    expect(document.sources).toHaveLength(1);
+    expect(document.components.length).toBeGreaterThanOrEqual(3); // root + methods
+    expect(document.program_bindings?.length).toBe(2);
+    expect(document.mcp_idl_bindings?.length).toBe(2);
+    expect(document.layout_regions?.length).toBeGreaterThan(0);
+    expect(document.ux_tasks?.length).toBeGreaterThan(0);
+    expect(document.state_variables?.map(v => v.variable_id).sort()).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('selected_path'),
+        expect.stringContaining('pin_job'),
+      ]),
+    );
+    expect(document.trust_bindings?.[0]?.subject_ref).toContain('sha256:');
+    expect(document.extensions?.[0]?.namespace).toBe(
+      'swissknife.mcp_ui_profile',
+    );
+
+    // Mapped semantics retained after decode/canonicalize.
+    const redecoded = decodeUiIr(uiIrToDict(document));
+    expect(uiIrSha256(redecoded)).toBe(uiIrSha256(document));
+    expect(redecoded.program_bindings?.map(b => b.target_ref).sort()).toEqual(
+      document.program_bindings?.map(b => b.target_ref).sort(),
+    );
+
+    // Every loss has a stable path + reason; paths are unique enough to audit.
+    const paths = result.losses.map(loss => loss.path);
+    expect(paths).toEqual([...paths].sort((a, b) => a.localeCompare(b, 'en')));
+    for (const loss of result.losses) {
+      expect(loss.path.length).toBeGreaterThan(0);
+      expect(loss.reason.length).toBeGreaterThan(0);
+    }
+
+    // Critical unmapped profile surfaces must appear in the loss list.
+    const joined = paths.join('\n');
+    expect(joined).toMatch(/permissions/);
+    expect(joined).toMatch(/control_surface_contract/);
+    expect(joined).toMatch(/observability/);
+    expect(joined).toMatch(/interaction_patterns/);
+    expect(joined).toMatch(/errors/);
+    expect(joined).toMatch(/compatibility/);
+    expect(joined).toMatch(/trust\.signature_material/);
+    expect(joined).toMatch(/state_model\.projections/);
+    expect(joined).toMatch(/state_model\.replay/);
+    expect(joined).toMatch(/data_contracts\.schemas/);
+    expect(joined).toMatch(/meta\.icon/);
+    expect(joined).toMatch(/stream/);
+    expect(joined).toMatch(/retry_policy/);
+    expect(joined).toMatch(/workflow_graph\.steps/);
+    expect(joined).toMatch(/services\[datasets\]\.transport_endpoint/);
+    expect(joined).toMatch(/input_schema|output_schema/);
+  });
+
+  it('produces a closed canonical document without inventing extra fields', () => {
+    const result = convertMcpUiProfileToUiIr(datasetDescriptor(), {
+      contentSha256: SHA_A,
+    });
+    const wire = uiIrToDict(result.document);
+    expect(Object.keys(wire).sort()).toEqual([...UIIR_DOCUMENT_FIELDS].sort());
+    const bytes = canonicalizeUiIr(result.document);
+    expect(bytes.byteLength).toBeGreaterThan(0);
+    expect(uiIrSha256(result.document)).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});

--- a/test/mcp-plus-plus/ui-ux-ir-cross-language.test.ts
+++ b/test/mcp-plus-plus/ui-ux-ir-cross-language.test.ts
@@ -1,0 +1,114 @@
+/**
+ * UIR-062: TypeScript side of cross-language golden vector parity.
+ *
+ * Loads the Python-authored golden_vectors.json and checks that the SwissKnife
+ * codec produces the same canonical sha256 for valid documents and fails closed
+ * on invalid documents.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  canonicalizeUiIr,
+  decodeUiIr,
+  uiIrSha256,
+  UI_UX_IR_SCHEMA_VERSION,
+} from '../../src/services/mcp/ui-ux-ir-codec.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function resolveGoldenPath(): string {
+  const candidates = [
+    // monorepo: swissknife/test/... → ../../external/ipfs_datasets/...
+    join(
+      __dirname,
+      '../../../external/ipfs_datasets/tests/fixtures/ui_ux_ir/v1/golden_vectors.json',
+    ),
+    // worktree with swissknife as submodule sibling layout
+    join(
+      __dirname,
+      '../../../../external/ipfs_datasets/tests/fixtures/ui_ux_ir/v1/golden_vectors.json',
+    ),
+  ];
+  for (const path of candidates) {
+    try {
+      readFileSync(path, 'utf8');
+      return path;
+    } catch {
+      // try next
+    }
+  }
+  throw new Error(`golden_vectors.json not found; tried: ${candidates.join(', ')}`);
+}
+
+interface GoldenFile {
+  interface: string;
+  schema_version?: string;
+  vectors: Array<{
+    id: string;
+    kind: string;
+    document?: Record<string, unknown>;
+    canonical_sha256?: string;
+    canonical_utf8_length?: number;
+    payload?: Record<string, unknown>;
+    semantic?: Record<string, unknown>;
+  }>;
+}
+
+describe('UIR-062 cross-language golden parity', () => {
+  const golden: GoldenFile = JSON.parse(readFileSync(resolveGoldenPath(), 'utf8'));
+
+  it('declares UIIRCrossLanguageParity@1', () => {
+    expect(golden.interface).toBe('UIIRCrossLanguageParity@1');
+    expect(golden.vectors.length).toBeGreaterThan(0);
+  });
+
+  it('matches Python canonical sha256 for valid documents', () => {
+    const valids = golden.vectors.filter((v) => v.kind === 'valid_document');
+    expect(valids.length).toBeGreaterThan(0);
+    for (const vector of valids) {
+      expect(vector.document).toBeTruthy();
+      const decoded = decodeUiIr(vector.document!);
+      expect(decoded.schema_version).toBe(UI_UX_IR_SCHEMA_VERSION);
+      const digest = uiIrSha256(decoded);
+      expect(digest).toBe(vector.canonical_sha256);
+      const bytes = canonicalizeUiIr(decoded);
+      if (typeof vector.canonical_utf8_length === 'number') {
+        expect(bytes.byteLength).toBe(vector.canonical_utf8_length);
+      }
+    }
+  });
+
+  it('fails closed on invalid documents', () => {
+    const invalids = golden.vectors.filter((v) => v.kind === 'invalid_document');
+    expect(invalids.length).toBeGreaterThan(0);
+    for (const vector of invalids) {
+      expect(() => decodeUiIr(vector.document!)).toThrow();
+    }
+  });
+
+  it('preserves decision/receipt fail-closed semantics', () => {
+    for (const vector of golden.vectors) {
+      if (vector.kind === 'decision') {
+        const payload = vector.payload ?? {};
+        const semantic = vector.semantic ?? {};
+        if (payload.outcome !== 'allow') {
+          expect(payload.can_execute).toBe(false);
+        }
+        if (semantic.can_execute === false) {
+          expect(payload.can_execute).toBe(false);
+        }
+      }
+      if (vector.kind === 'receipt') {
+        const payload = vector.payload ?? {};
+        const semantic = vector.semantic ?? {};
+        if (semantic.has_invocation === false) {
+          expect(payload.has_invocation).toBe(false);
+        }
+      }
+    }
+  });
+});

--- a/test/mcp-plus-plus/ui-ux-ir-dynamic-renderer-security.test.ts
+++ b/test/mcp-plus-plus/ui-ux-ir-dynamic-renderer-security.test.ts
@@ -1,0 +1,182 @@
+/**
+ * UIR-035: UIIRDynamicRendererSecurity@1
+ *
+ * Hostile descriptor/result payloads, CSP/escaping, direct-network spy,
+ * and governed invocation receipt coverage.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ORBDynamicAppRenderer,
+  UIIR_DYNAMIC_RENDERER_SECURITY_INTERFACE,
+  escapeHtml,
+  looksHostile,
+  sanitizeDescriptorText,
+  type IDLDescriptor,
+  type GovernedOrbInvoker,
+} from '../../web/src/orb-dynamic-app-renderer.ts';
+
+function hostileDescriptor(): IDLDescriptor {
+  return {
+    name: 'evil"><script>alert(1)</script>',
+    namespace: 'ns<script>',
+    version: '1.0.0',
+    ui: {
+      display_name: '<img src=x onerror=alert(1)>',
+      icon: 'javascript:alert(1)',
+    },
+    ui_ir_cid: 'bafyuiirtest',
+    action_binding_id: 'binding:submit',
+    policy_cid: 'bafypolicy',
+    methods: [
+      {
+        name: 'run"><script>',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            prompt: { type: 'string' },
+          },
+          required: ['prompt'],
+        },
+        outputSchema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+      },
+    ],
+  };
+}
+
+describe('UIIRDynamicRendererSecurity@1', () => {
+  it('exports the stable interface identity', () => {
+    expect(UIIR_DYNAMIC_RENDERER_SECURITY_INTERFACE).toBe(
+      'UIIRDynamicRendererSecurity@1',
+    );
+  });
+
+  it('escapes and detects hostile markup', () => {
+    expect(escapeHtml('<script>x</script>')).toBe(
+      '&lt;script&gt;x&lt;/script&gt;',
+    );
+    expect(looksHostile('javascript:alert(1)')).toBe(true);
+    expect(looksHostile('safe label')).toBe(false);
+    expect(sanitizeDescriptorText('<script>bad</script>')).toContain(
+      'blocked unsafe content',
+    );
+  });
+
+  it('renders hostile descriptors as inert HTML (no raw script/url injection)', () => {
+    const renderer = new ORBDynamicAppRenderer({
+      governedInvoker: async () => ({ outcome: 'deny', explanation: 'n/a' }),
+    });
+    const html = renderer.renderApp(hostileDescriptor());
+
+    expect(html).toContain(UIIR_DYNAMIC_RENDERER_SECURITY_INTERFACE);
+    // Raw executable fragments must not appear unescaped.
+    expect(html).not.toMatch(/<script>/i);
+    expect(html).not.toMatch(/onerror=/i);
+    expect(html).not.toMatch(/javascript:/i);
+    // Escaped or neutralized forms are present.
+    expect(html.includes('&lt;') || html.includes('blocked unsafe')).toBe(true);
+  });
+
+  it('blocks direct HTTP when no governed invoker is configured', async () => {
+    const fetchSpy = vi.fn();
+    // @ts-expect-error test spy
+    globalThis.fetch = fetchSpy;
+
+    const renderer = new ORBDynamicAppRenderer({ blockDirectHttp: true });
+    const container = document.createElement('div');
+    const descriptor = hostileDescriptor();
+    container.innerHTML = renderer.renderApp(descriptor);
+    renderer.bindEvents(container, descriptor);
+
+    const btn = container.querySelector('.orb-invoke-btn') as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    await btn.click();
+    // allow microtasks from async handler
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(renderer.blockedDirectHttpAttempts.length).toBeGreaterThan(0);
+    const panel = container.querySelector('.orb-result-panel')!;
+    expect(panel.textContent || '').toMatch(/blocked|governed|deny/i);
+    // Denial remains visible/accessible.
+    expect(panel.querySelector('[role="alert"], [role="alertdialog"]')).toBeTruthy();
+  });
+
+  it('routes allow outcomes only through the governed invoker', async () => {
+    const calls: unknown[] = [];
+    const invoker: GovernedOrbInvoker = async (req) => {
+      calls.push(req);
+      return {
+        outcome: 'allow',
+        data: { ok: true, note: '<script>xss</script>' },
+        decisionId: 'dec-1',
+        receiptId: 'rcpt-1',
+      };
+    };
+    const fetchSpy = vi.fn();
+    // @ts-expect-error test spy
+    globalThis.fetch = fetchSpy;
+
+    const renderer = new ORBDynamicAppRenderer({ governedInvoker: invoker });
+    const container = document.createElement('div');
+    const descriptor: IDLDescriptor = {
+      name: 'safe-app',
+      methods: [
+        {
+          name: 'list_datasets',
+          inputSchema: { type: 'object', properties: {} },
+          outputSchema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+        },
+      ],
+      ui_ir_cid: 'bafyui',
+      action_binding_id: 'binding:list',
+      policy_cid: 'bafypol',
+    };
+    container.innerHTML = renderer.renderApp(descriptor);
+    renderer.bindEvents(container, descriptor);
+    await (container.querySelector('.orb-invoke-btn') as HTMLButtonElement).click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(calls).toHaveLength(1);
+    const req = calls[0] as { method: string; uiIrCid?: string; policyCid?: string };
+    expect(req.method).toBe('list_datasets');
+    expect(req.uiIrCid).toBe('bafyui');
+    expect(req.policyCid).toBe('bafypol');
+
+    const panel = container.querySelector('.orb-result-panel')!;
+    // Result payload script is escaped, not live.
+    expect(panel.innerHTML).not.toMatch(/<script>xss<\/script>/i);
+    expect(panel.innerHTML).toMatch(/&lt;script&gt;xss&lt;\/script&gt;/);
+    expect(panel.textContent || '').toMatch(/decision: dec-1|rcpt-1/);
+  });
+
+  it('keeps denial and confirmation visible with accessible roles', async () => {
+    const invoker: GovernedOrbInvoker = async () => ({
+      outcome: 'require_confirmation',
+      explanation: 'Confirm destructive action',
+      decisionId: 'dec-confirm',
+    });
+    const renderer = new ORBDynamicAppRenderer({ governedInvoker: invoker });
+    const container = document.createElement('div');
+    const descriptor: IDLDescriptor = {
+      name: 'app',
+      methods: [
+        {
+          name: 'delete',
+          inputSchema: { type: 'object', properties: {} },
+          outputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    };
+    container.innerHTML = renderer.renderApp(descriptor);
+    renderer.bindEvents(container, descriptor);
+    await (container.querySelector('.orb-invoke-btn') as HTMLButtonElement).click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const panel = container.querySelector('.orb-result-panel')!;
+    expect(panel.querySelector('[role="alertdialog"]')).toBeTruthy();
+    expect(panel.textContent || '').toMatch(/REQUIRE_CONFIRMATION|Confirm destructive/i);
+  });
+});

--- a/test/mcp-plus-plus/ui-ux-ir-glasses-adapter.test.ts
+++ b/test/mcp-plus-plus/ui-ux-ir-glasses-adapter.test.ts
@@ -1,0 +1,317 @@
+/**
+ * UIR-043: Meta-glasses and spatial projection adapter (TypeScript).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  ARROW_ENTER_TOKENS,
+  UNSUPPORTED_GLASSES_ASSUMPTIONS,
+  UIIRGlassesAdapter,
+  UIIRGlassesAdapterError,
+  UIIR_GLASSES_ADAPTER_INTERFACE,
+  UIIR_GLASSES_PROJECTION_INTERFACE,
+  defaultInputBindings,
+  glassesCapabilityProfile,
+  isSupportedArrowEnterToken,
+  normalizeArrowEnterIntent,
+  normalizeGlassesIntent,
+  projectUIIRToGlasses,
+  rejectFabricatedCapabilityClaims,
+  renderPathForCapabilityPath,
+  type GlassesProjectionRequest,
+  type GlassesSemanticItem,
+} from '../../src/services/glasses/ui-ux-ir-glasses-adapter';
+
+function pilotItems(extraActions = 0): GlassesSemanticItem[] {
+  const items: GlassesSemanticItem[] = [
+    {
+      item_id: 'action_primary',
+      semantic_kind: 'action',
+      mandatory: true,
+      label: 'Primary',
+      action_cost: 1,
+      text_chars: 20,
+      field_of_view_share: 8,
+      attention_cost: 5,
+      priority: 10,
+      fallback_ref: 'fallback:mobile:action_primary',
+      fallback_capability_ids: ['mobile_companion', 'audio'],
+    },
+    {
+      item_id: 'confirm_delete',
+      semantic_kind: 'confirmation',
+      mandatory: true,
+      label: 'Confirm delete',
+      action_cost: 1,
+      text_chars: 48,
+      field_of_view_share: 10,
+      attention_cost: 7,
+      priority: 5,
+      fallback_ref: 'fallback:audio:confirm_delete',
+      fallback_capability_ids: ['audio', 'mobile_companion'],
+    },
+    {
+      item_id: 'privacy_mic',
+      semantic_kind: 'privacy',
+      mandatory: true,
+      label: 'Mic privacy',
+      action_cost: 0,
+      text_chars: 40,
+      field_of_view_share: 6,
+      attention_cost: 4,
+      priority: 1,
+      fallback_ref: 'fallback:audio:privacy_mic',
+      fallback_capability_ids: ['audio', 'mobile_companion'],
+    },
+    {
+      item_id: 'feedback_ok',
+      semantic_kind: 'feedback',
+      mandatory: true,
+      label: 'Done',
+      action_cost: 0,
+      text_chars: 24,
+      field_of_view_share: 4,
+      attention_cost: 3,
+      priority: 20,
+      fallback_ref: 'fallback:audio:feedback_ok',
+      fallback_capability_ids: ['audio', 'notification'],
+    },
+  ];
+  for (let index = 0; index < extraActions; index += 1) {
+    items.push({
+      item_id: `action_extra_${index}`,
+      semantic_kind: 'action',
+      mandatory: true,
+      label: `Extra ${index}`,
+      action_cost: 1,
+      text_chars: 30,
+      field_of_view_share: 10,
+      attention_cost: 5,
+      priority: 50 + index,
+      fallback_ref: `fallback:mobile:action_extra_${index}`,
+      fallback_capability_ids: ['mobile_companion', 'audio'],
+    });
+  }
+  return items;
+}
+
+function request(
+  overrides: Partial<GlassesProjectionRequest> = {},
+): GlassesProjectionRequest {
+  return {
+    document_id: 'doc:glasses-pilot',
+    capability_path: 'web_app',
+    items: pilotItems(),
+    title: 'Glasses pilot',
+    ...overrides,
+  };
+}
+
+describe('UIIRGlassesAdapter@1 capability paths', () => {
+  it('keeps DAT and Web App capability paths distinct', () => {
+    const dat = glassesCapabilityProfile('dat');
+    const web = glassesCapabilityProfile('web_app');
+    expect(dat.profile_id).not.toBe(web.profile_id);
+    expect(dat.render_path).toBe('dat-native');
+    expect(web.render_path).toBe('display-webapp');
+    expect(dat.input_capability_ids).toContain('hand_gesture');
+    expect(web.input_capability_ids).not.toContain('hand_gesture');
+    expect(renderPathForCapabilityPath('dat')).toBe('dat-native');
+    expect(renderPathForCapabilityPath('web_app')).toBe('display-webapp');
+    expect(dat.raw_emg).toBe(false);
+    expect(web.continuous_cursor).toBe(false);
+    expect(web.freeform_touch).toBe(false);
+    expect(web.continuous_text_input).toBe(false);
+  });
+
+  it('rejects fabricated capability claims and collapsed paths', () => {
+    expect(() =>
+      rejectFabricatedCapabilityClaims({ raw_emg: true }),
+    ).toThrow(UIIRGlassesAdapterError);
+    expect(() =>
+      rejectFabricatedCapabilityClaims({ dat_webapp_collapsed: true }),
+    ).toThrow(/collapsed/);
+    expect(() =>
+      rejectFabricatedCapabilityClaims({ emg_raw: 'sample' }),
+    ).toThrow(/Raw EMG/);
+    expect(() =>
+      rejectFabricatedCapabilityClaims({
+        raw_emg: false,
+        continuous_cursor: false,
+        dat_webapp_collapsed: false,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('Arrow/Enter Neural Band and captouch mapping', () => {
+  it('maps Arrow and Enter tokens to abstract intents only', () => {
+    expect(normalizeArrowEnterIntent('ArrowUp')).toBe('navigate_up');
+    expect(normalizeArrowEnterIntent('ArrowDown')).toBe('navigate_down');
+    expect(normalizeArrowEnterIntent('ArrowLeft')).toBe('navigate_left');
+    expect(normalizeArrowEnterIntent('ArrowRight')).toBe('navigate_right');
+    expect(normalizeArrowEnterIntent('Enter')).toBe('activate');
+    expect(normalizeArrowEnterIntent('enter')).toBe('activate');
+    expect(isSupportedArrowEnterToken('ArrowUp')).toBe(true);
+    expect(isSupportedArrowEnterToken('MouseMove')).toBe(false);
+    expect(() => normalizeArrowEnterIntent('MouseMove')).toThrow(
+      /Arrow\/Enter/,
+    );
+    expect(() => normalizeArrowEnterIntent('emg_burst')).toThrow(
+      UIIRGlassesAdapterError,
+    );
+  });
+
+  it('binds Neural Band/captouch/D-pad to Arrow/Enter tokens without raw EMG', () => {
+    const bindings = defaultInputBindings('web_app');
+    expect(bindings.map(b => b.source).sort()).toEqual([
+      'captouch',
+      'dpad',
+      'neural_band',
+    ]);
+    for (const binding of bindings) {
+      expect(binding.admitted_tokens).toEqual([...ARROW_ENTER_TOKENS]);
+      expect(binding.raw_emg_allowed).toBe(false);
+      expect(binding.continuous_cursor_allowed).toBe(false);
+      expect(binding.freeform_touch_allowed).toBe(false);
+      expect(binding.continuous_text_input_allowed).toBe(false);
+    }
+    const neural = normalizeGlassesIntent('Enter', {
+      source: 'neural_band',
+      capability_path: 'web_app',
+    });
+    expect(neural.intent).toBe('activate');
+    expect(neural.raw_emg).toBe(false);
+    expect(neural.continuous_cursor).toBe(false);
+    const captouch = normalizeGlassesIntent('ArrowRight', {
+      source: 'captouch',
+    });
+    expect(captouch.intent).toBe('navigate_right');
+  });
+});
+
+describe('projectUIIRToGlasses', () => {
+  it('preserves privacy indicators and confirmations on Web App path', () => {
+    const projection = projectUIIRToGlasses(request());
+    expect(projection.interface).toBe(UIIR_GLASSES_PROJECTION_INTERFACE);
+    expect(projection.capability_path).toBe('web_app');
+    expect(projection.capability_receipt.dat_webapp_collapsed).toBe(false);
+    expect(projection.capability_receipt.render_path).toBe('display-webapp');
+
+    const confirm = projection.nodes.find(n => n.semantic_kind === 'confirmation');
+    const privacy = projection.nodes.find(n => n.semantic_kind === 'privacy');
+    expect(confirm).toBeDefined();
+    expect(privacy).toBeDefined();
+    expect(confirm?.surface).toBe('confirmation');
+    expect(privacy?.surface).toBe('privacy_indicator');
+    expect(confirm?.disposition).not.toBe('omitted');
+    expect(privacy?.disposition).not.toBe('omitted');
+
+    const unsupported = new Set(
+      projection.losses
+        .filter(
+          loss =>
+            loss.category === 'unsupported' &&
+            loss.semantic_id.startsWith('assumption:'),
+        )
+        .map(loss => loss.semantic_id.replace('assumption:', '')),
+    );
+    for (const assumption of UNSUPPORTED_GLASSES_ASSUMPTIONS) {
+      expect(unsupported.has(assumption)).toBe(true);
+    }
+  });
+
+  it('uses DAT-native render path without collapsing Web App profile', () => {
+    const dat = projectUIIRToGlasses(request({ capability_path: 'dat' }));
+    const web = projectUIIRToGlasses(request({ capability_path: 'web_app' }));
+    expect(dat.profile_id).toBe('profile:glasses:dat');
+    expect(dat.compiler_handoff.render_path).toBe('dat-native');
+    expect(dat.compiler_handoff.input_kinds).toContain('gesture');
+    expect(web.compiler_handoff.render_path).toBe('display-webapp');
+    expect(dat.profile_id).not.toBe(web.profile_id);
+  });
+
+  it('emits action/text/update/FOV budget receipts under pressure', () => {
+    const projection = projectUIIRToGlasses(
+      request({ items: pilotItems(8) }),
+    );
+    expect(projection.budget_receipt.action_limit).toBe(4);
+    expect(projection.budget_receipt.text_limit).toBe(180);
+    expect(projection.budget_receipt.update_limit).toBe(10);
+    expect(projection.budget_receipt.field_of_view_limit).toBe(30);
+    const fallbackOrUnsat = projection.nodes.filter(
+      n => n.disposition === 'fallback' || n.disposition === 'unsatisfiable',
+    );
+    expect(fallbackOrUnsat.length).toBeGreaterThan(0);
+    expect(['fallback', 'unsatisfiable', 'degraded']).toContain(
+      projection.status,
+    );
+  });
+
+  it('routes continuous text input to mobile fallback rather than fabricating text entry', () => {
+    const projection = projectUIIRToGlasses(
+      request({
+        items: [
+          {
+            item_id: 'privacy_core',
+            semantic_kind: 'privacy',
+            mandatory: true,
+            label: 'Privacy',
+            priority: 1,
+            fallback_capability_ids: ['audio'],
+          },
+          {
+            item_id: 'text_entry',
+            semantic_kind: 'text_input',
+            mandatory: true,
+            label: 'Type a note',
+            priority: 20,
+            fallback_ref: 'fallback:mobile:text_entry',
+            fallback_capability_ids: ['mobile_companion'],
+          },
+        ],
+      }),
+    );
+    const textNode = projection.nodes.find(n => n.semantic_id === 'text_entry');
+    expect(textNode).toBeDefined();
+    expect(textNode?.disposition).toBe('fallback');
+    expect(textNode?.surface).toBe('mobile_fallback');
+    expect(
+      projection.losses.some(
+        loss =>
+          loss.semantic_id === 'text_entry' && loss.category === 'fallback',
+      ),
+    ).toBe(true);
+  });
+
+  it('produces compiler handoff compatible with glasses display compiler inputs', () => {
+    const projection = projectUIIRToGlasses(request());
+    const handoff = projection.compiler_handoff;
+    expect(['single-card', 'stack', 'confirmation']).toContain(handoff.template);
+    expect(['dat-native', 'display-webapp', 'simulator']).toContain(
+      handoff.render_path,
+    );
+    expect(handoff.max_actions).toBeGreaterThanOrEqual(1);
+    expect(handoff.max_text_chars).toBeGreaterThan(0);
+    expect(handoff.max_update_hz).toBeGreaterThan(0);
+    expect(Array.isArray(handoff.actions)).toBe(true);
+    expect(Array.isArray(handoff.regions)).toBe(true);
+    expect(Array.isArray(handoff.fallbacks)).toBe(true);
+    expect(handoff.input_kinds).toContain('dpad');
+  });
+
+  it('exposes class adapter API aligned with UIIRGlassesAdapter@1', () => {
+    const adapter = new UIIRGlassesAdapter('web_app');
+    expect(adapter.interface).toBe(UIIR_GLASSES_ADAPTER_INTERFACE);
+    expect(adapter.normalizeIntent('Enter').intent).toBe('activate');
+    const projection = adapter.project(request());
+    expect(projection.capability_path).toBe('web_app');
+    expect(adapter.inputBindings()).toHaveLength(3);
+  });
+
+  it('fails closed on empty items and unknown paths', () => {
+    expect(() => projectUIIRToGlasses({ items: [] })).toThrow(/non-empty/);
+    expect(() =>
+      glassesCapabilityProfile('hololens' as 'web_app'),
+    ).toThrow(/Unknown glasses capability path/);
+  });
+});

--- a/test/mcp-plus-plus/ui-ux-ir-orb-mediation.test.ts
+++ b/test/mcp-plus-plus/ui-ux-ir-orb-mediation.test.ts
@@ -1,0 +1,652 @@
+/**
+ * UIR-033 — UI/UX IR integration with deontic broker, control-surface mediator,
+ * and ORB capability router (UIIRORBBridge@1 / ControlSurfaceMediation@1).
+ *
+ * Evidence criteria (spy executor + exact receipts):
+ * - Hidden/enabled presentation never authorizes
+ * - Policy identity + current real input mandatory for unary and streaming
+ * - Every invocation re-evaluates current policy
+ * - Blocking / missing-policy outcomes never call transport
+ * - Duplicate correlated inputs call transport at most once
+ * - Actor/delegation/UI/action/IDL/policy/state/decision/invocation IDs retained
+ * - Existing non-UIIR descriptors remain compatible through explicit adapters
+ */
+
+import {
+  projectDeonticInterface,
+  projectUIIRDeonticInterface,
+  adaptNonUIIRDescriptorToORBBridge,
+  presentationStateFromDeontic,
+  assertPresentationDoesNotAuthorize,
+  resolveUIIRActionBinding,
+  retainUIIRMediationIdentity,
+  createDeonticORBEvaluator,
+  UIIR_ORB_BRIDGE_INTERFACE,
+  PolicyEngine,
+  type Policy,
+} from '../../src/services/mcp/mcp-deontic-interface-broker';
+import {
+  control_surface_mediator,
+  mediateControlSurfaceInvocation,
+  mediateLegacyControlSurfaceInvocation,
+  type ControlSurfacePolicyEvaluationRequest,
+  type ControlSurfaceORBLikeBinding,
+} from '../../src/services/mcp/mcp-control-surface-mediator';
+import {
+  MCPCapabilityRouter,
+  LocalORBTransportAdapter,
+  createDefaultORBAdapters,
+  type ORBDescriptorSource,
+} from '../../src/services/mcp/mcp-orb-capability-router';
+import { ipfsDatasetsUIProfileDescriptor } from '../../src/services/ipfs/mcp-ipfs-ui-descriptors';
+import type { InterfaceDescriptor } from '../../src/services/mcp/mcp-idl';
+import type { MCPUIProfileDescriptor } from '../../src/services/mcp/mcp-ui-profile';
+
+const DATASET_INTERFACE_CID = 'sha256:dataset-fixture';
+const UI_IR_CID = 'sha256:uiir-dataset-workbench';
+
+function localDatasetDescriptor(): MCPUIProfileDescriptor {
+  const descriptor = JSON.parse(JSON.stringify(ipfsDatasetsUIProfileDescriptor)) as MCPUIProfileDescriptor;
+  descriptor.services = descriptor.services.map(service => ({
+    ...service,
+    transport: 'local',
+    endpoint: 'local://ipfs_datasets_py',
+  }));
+  return descriptor;
+}
+
+function source(): ORBDescriptorSource {
+  return { cid: DATASET_INTERFACE_CID, descriptor: localDatasetDescriptor() };
+}
+
+function datasetInterface(): InterfaceDescriptor {
+  return ipfsDatasetsUIProfileDescriptor as InterfaceDescriptor;
+}
+
+function permitAllExceptPublish(): Policy {
+  return {
+    id: 'dataset-policy',
+    version: '1.0.0',
+    permissions: [{ cap: '*', rsc: '*' }],
+    prohibitions: [{ cap: 'mcp++/invoke:publish', rsc: '*' }],
+    obligations: [],
+  };
+}
+
+function allowControlSurfaceEvaluation(request: ControlSurfacePolicyEvaluationRequest) {
+  return {
+    outcome: 'allow' as const,
+    reasons: ['Test runtime policy evaluator allowed ORB invocation.'],
+    explanation: `allowed ${request.interaction_envelope.normalized_intent.method}`,
+    metadata: {
+      test_policy_evaluator: 'hallucinate_app.control_surface_mediator.evaluate_control_surface_interaction',
+      saw_input: request.input,
+      policy_cid: request.context.policy_cid,
+    },
+  };
+}
+
+function denyControlSurfaceEvaluation(request: ControlSurfacePolicyEvaluationRequest) {
+  return {
+    outcome: 'deny' as const,
+    reasons: [`Denied by test policy for ${request.interaction_envelope.normalized_intent.method}`],
+    explanation: 'test deny',
+    metadata: { saw_input: request.input },
+  };
+}
+
+function orbBinding(method = 'browse'): ControlSurfaceORBLikeBinding {
+  const descriptor = localDatasetDescriptor();
+  return {
+    interface_cid: DATASET_INTERFACE_CID,
+    descriptor,
+    service: { id: descriptor.services[0]?.id ?? 'ipfs_datasets' },
+    operation: { method },
+  };
+}
+
+describe('UIR-033 UIIRORBBridge@1 — deontic presentation is advisory', () => {
+  it('projects UIIR action bindings with advisory presentation, never as authorization', () => {
+    const bridge = projectUIIRDeonticInterface(datasetInterface(), permitAllExceptPublish(), {
+      ui_ir_cid: UI_IR_CID,
+      action_ids: { browse: 'action:browse', publish: 'action:publish' },
+    });
+
+    expect(bridge.interface).toBe(UIIR_ORB_BRIDGE_INTERFACE);
+    expect(bridge.ui_ir_cid).toBe(UI_IR_CID);
+    expect(bridge.legacy_adapter).toBe(false);
+
+    const browse = resolveUIIRActionBinding(bridge, 'browse');
+    const publish = resolveUIIRActionBinding(bridge, 'publish');
+    expect(browse?.presentation.visibility).toBe('enabled');
+    expect(publish?.presentation.visibility).toBe('hidden');
+
+    // Presentation must never be treated as a permit.
+    const presentationClaim = assertPresentationDoesNotAuthorize(
+      browse!.presentation,
+      'permit',
+    );
+    expect(presentationClaim.authorized).toBe(false);
+    expect(presentationClaim.reasons.join(' ')).toMatch(/never authorizes|advisory/i);
+  });
+
+  it('maps deontic states to presentation without elevating them to policy grants', () => {
+    expect(presentationStateFromDeontic('prohibited').visibility).toBe('hidden');
+    expect(presentationStateFromDeontic('unavailable').visibility).toBe('disabled');
+    expect(presentationStateFromDeontic('permitted').visibility).toBe('enabled');
+    expect(presentationStateFromDeontic('obligated').visibility).toBe('enabled');
+
+    const enabled = assertPresentationDoesNotAuthorize({ visibility: 'enabled' });
+    const hidden = assertPresentationDoesNotAuthorize({ visibility: 'hidden' });
+    expect(enabled.authorized).toBe(false);
+    expect(hidden.authorized).toBe(false);
+  });
+
+  it('adapts existing non-UIIR descriptors through an explicit legacy adapter', () => {
+    const adapted = adaptNonUIIRDescriptorToORBBridge(datasetInterface(), permitAllExceptPublish());
+    expect(adapted.legacy_adapter).toBe(true);
+    expect(adapted.ui_ir_cid).toBeUndefined();
+    expect(adapted.interface).toBe(UIIR_ORB_BRIDGE_INTERFACE);
+    expect(adapted.actions.length).toBeGreaterThan(0);
+
+    // Same formal projection as the classic path.
+    const classic = projectDeonticInterface(datasetInterface(), permitAllExceptPublish());
+    expect(adapted.projection.prohibited).toEqual(classic.prohibited);
+    expect(adapted.policy_decisions.publish.visibility).toBe('hidden');
+  });
+
+  it('retains actor/delegation/UI/action/IDL/policy/state/decision/invocation IDs', () => {
+    const retained = retainUIIRMediationIdentity({
+      actor_id: 'did:key:alice',
+      delegation_chain: ['did:key:alice', 'did:key:bob'],
+      ui_ir_cid: UI_IR_CID,
+      action_id: 'action:browse',
+      interface_cid: DATASET_INTERFACE_CID,
+      policy_cid: 'sha256:policy-1',
+      state_id: 'state:ready',
+      decision_id: 'decision:1',
+      invocation_id: 'inv:1',
+      correlation_id: 'corr-1',
+    });
+    expect(retained).toEqual(expect.objectContaining({
+      actor_id: 'did:key:alice',
+      ui_ir_cid: UI_IR_CID,
+      action_id: 'action:browse',
+      interface_cid: DATASET_INTERFACE_CID,
+      policy_cid: 'sha256:policy-1',
+      state_id: 'state:ready',
+      decision_id: 'decision:1',
+      invocation_id: 'inv:1',
+      correlation_id: 'corr-1',
+    }));
+    expect(retained).not.toHaveProperty('presentation');
+  });
+});
+
+describe('UIR-033 ControlSurfaceMediation@1 — presentation never authorizes', () => {
+  it('rejects presentation-claimed authorization even when a policy evaluator would allow', async () => {
+    let evaluatorCalls = 0;
+    const result = await mediateControlSurfaceInvocation({
+      binding: orbBinding('browse'),
+      input: { path: '/' },
+      context: {
+        correlation_id: 'corr-presentation',
+        caller_did: 'did:key:alice',
+        policy_cid: 'sha256:policy-1',
+        uiir: {
+          ui_ir_cid: UI_IR_CID,
+          action_id: 'action:browse',
+          presentation: {
+            visibility: 'enabled',
+            authorizes: true,
+          },
+        },
+        control_surface: {
+          surface: 'mouse',
+          surface_event: 'click',
+          actor: { type: 'user', id: 'did:key:alice', delegation_chain: ['did:key:alice'] },
+        },
+      },
+      policy_evaluator: (request) => {
+        evaluatorCalls += 1;
+        return allowControlSurfaceEvaluation(request);
+      },
+      require_uiir_mediation: true,
+    });
+
+    expect(result.can_invoke).toBe(false);
+    expect(result.policy_decision.outcome).toBe('deny');
+    expect(result.policy_decision.reasons.join('\n')).toMatch(/presentation|never authorizes/i);
+    // Fail closed before evaluator when presentation claims a grant.
+    expect(evaluatorCalls).toBe(0);
+    expect(result.retained_identities?.ui_ir_cid).toBe(UI_IR_CID);
+    expect(result.retained_identities?.action_id).toBe('action:browse');
+    expect(result.retained_identities?.actor_id).toBe('did:key:alice');
+  });
+
+  it('requires policy identity and real input under UIIR mediation', async () => {
+    const missingPolicy = await mediateControlSurfaceInvocation({
+      binding: orbBinding('browse'),
+      input: { path: '/' },
+      context: {
+        correlation_id: 'corr-no-policy',
+        uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:browse' },
+      },
+      policy_evaluator: allowControlSurfaceEvaluation,
+      require_uiir_mediation: true,
+    });
+    expect(missingPolicy.can_invoke).toBe(false);
+    expect(missingPolicy.policy_decision.reasons.join('\n')).toMatch(/policy identity/i);
+
+    const missingInput = await mediateControlSurfaceInvocation({
+      binding: orbBinding('browse'),
+      input: {},
+      context: {
+        correlation_id: 'corr-no-input',
+        policy_cid: 'sha256:policy-1',
+        uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:browse' },
+      },
+      policy_evaluator: allowControlSurfaceEvaluation,
+      require_uiir_mediation: true,
+    });
+    expect(missingInput.can_invoke).toBe(false);
+    expect(missingInput.policy_decision.reasons.join('\n')).toMatch(/real input/i);
+  });
+
+  it('re-evaluates policy with the actual input on every mediation call', async () => {
+    const seenInputs: unknown[] = [];
+    const evaluator = (request: ControlSurfacePolicyEvaluationRequest) => {
+      seenInputs.push(request.input);
+      const path = (request.input as { path?: string })?.path;
+      if (path === '/deny-me') {
+        return denyControlSurfaceEvaluation(request);
+      }
+      return allowControlSurfaceEvaluation(request);
+    };
+
+    const first = await control_surface_mediator({
+      binding: orbBinding('browse'),
+      input: { path: '/ok' },
+      context: {
+        correlation_id: 'corr-reeval-1',
+        policy_cid: 'sha256:policy-1',
+        uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:browse' },
+      },
+      policy_evaluator: evaluator,
+    });
+    const second = await control_surface_mediator({
+      binding: orbBinding('browse'),
+      input: { path: '/deny-me' },
+      context: {
+        correlation_id: 'corr-reeval-2',
+        policy_cid: 'sha256:policy-1',
+        uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:browse' },
+      },
+      policy_evaluator: evaluator,
+    });
+
+    expect(first.can_invoke).toBe(true);
+    expect(second.can_invoke).toBe(false);
+    expect(seenInputs).toEqual([{ path: '/ok' }, { path: '/deny-me' }]);
+  });
+
+  it('keeps non-UIIR descriptors compatible through the explicit legacy adapter', async () => {
+    const result = await mediateLegacyControlSurfaceInvocation({
+      binding: orbBinding('browse'),
+      input: { path: '/' },
+      context: { correlation_id: 'corr-legacy' },
+      policy_evaluator: allowControlSurfaceEvaluation,
+    });
+    expect(result.can_invoke).toBe(true);
+    expect(result.policy_decision.outcome).toBe('allow');
+    expect(result.retained_identities?.interface_cid).toBe(DATASET_INTERFACE_CID);
+  });
+});
+
+describe('UIR-033 ORB mediation — fail-closed transport with spy executor', () => {
+  it('never calls transport when presentation claims authorization', async () => {
+    let handlerCalls = 0;
+    const local = new LocalORBTransportAdapter();
+    local.registerHandler('browse', () => {
+      handlerCalls += 1;
+      return { entries: [] };
+    });
+    const router = new MCPCapabilityRouter({
+      adapters: createDefaultORBAdapters(local),
+      control_surface_policy_evaluator: allowControlSurfaceEvaluation,
+    });
+    const binding = await router.bind({ descriptors: [source()], operation: 'browse' });
+
+    const response = await router.invoke({
+      handle: binding.handle,
+      input: { path: '/' },
+      context: {
+        correlation_id: 'corr-pres-deny',
+        capabilities: ['dataset/read'],
+        policy_cid: 'sha256:policy-1',
+        uiir: {
+          ui_ir_cid: UI_IR_CID,
+          action_id: 'action:browse',
+          presentation: { visibility: 'enabled', authorizes: true },
+        },
+      },
+    });
+
+    expect(response.denied).toBe(true);
+    expect(handlerCalls).toBe(0);
+    expect(response.receipt.policy_decision.reasons.join('\n')).toMatch(/presentation|never authorizes/i);
+  });
+
+  it('fails closed without transport when UIIR policy identity is missing', async () => {
+    let handlerCalls = 0;
+    const local = new LocalORBTransportAdapter();
+    local.registerHandler('browse', () => {
+      handlerCalls += 1;
+      return { entries: [] };
+    });
+    const router = new MCPCapabilityRouter({
+      adapters: createDefaultORBAdapters(local),
+      control_surface_policy_evaluator: allowControlSurfaceEvaluation,
+    });
+    const binding = await router.bind({ descriptors: [source()], operation: 'browse' });
+
+    const response = await router.invoke({
+      handle: binding.handle,
+      input: { path: '/' },
+      context: {
+        correlation_id: 'corr-missing-policy',
+        capabilities: ['dataset/read'],
+        uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:browse' },
+      },
+    });
+
+    expect(response.denied).toBe(true);
+    expect(handlerCalls).toBe(0);
+    expect(response.receipt.policy_decision.reasons.join('\n')).toMatch(/policy identity/i);
+  });
+
+  it('fails closed for blocking control-surface outcomes (deny/confirm/defer/rate_limit)', async () => {
+    const outcomes = ['deny', 'require_confirmation', 'defer', 'rate_limit'] as const;
+    for (const outcome of outcomes) {
+      let handlerCalls = 0;
+      const local = new LocalORBTransportAdapter();
+      local.registerHandler('browse', () => {
+        handlerCalls += 1;
+        return { entries: [] };
+      });
+      const router = new MCPCapabilityRouter({
+        adapters: createDefaultORBAdapters(local),
+        control_surface_policy_evaluator: () => ({
+          outcome,
+          reasons: [`blocked:${outcome}`],
+          explanation: `blocked ${outcome}`,
+        }),
+      });
+      const binding = await router.bind({ descriptors: [source()], operation: 'browse' });
+      const response = await router.invoke({
+        handle: binding.handle,
+        input: { path: '/' },
+        context: {
+          correlation_id: `corr-block-${outcome}`,
+          capabilities: ['dataset/read'],
+          policy_cid: 'sha256:policy-1',
+          uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:browse' },
+        },
+      });
+      expect(response.denied).toBe(true);
+      expect(handlerCalls).toBe(0);
+      expect(response.receipt.mediation_receipt?.policy_decision.outcome).toBe(outcome);
+    }
+  });
+
+  it('re-evaluates deontic policy on every unary invocation with current policy identity', async () => {
+    const engine = new PolicyEngine();
+    const policyCid = engine.registerPolicy({
+      id: 'flip',
+      version: '1',
+      permissions: [{ cap: '*', rsc: '*' }],
+      prohibitions: [],
+      obligations: [],
+    });
+
+    let handlerCalls = 0;
+    const local = new LocalORBTransportAdapter();
+    local.registerHandler('browse', () => {
+      handlerCalls += 1;
+      return { entries: [{ name: 'ok' }] };
+    });
+    const router = new MCPCapabilityRouter({
+      adapters: createDefaultORBAdapters(local),
+      control_surface_policy_evaluator: allowControlSurfaceEvaluation,
+      deontic_evaluator: createDeonticORBEvaluator(engine),
+    });
+    const binding = await router.bind({ descriptors: [source()], operation: 'browse' });
+
+    const first = await router.invoke({
+      handle: binding.handle,
+      input: { path: '/a' },
+      context: {
+        correlation_id: 'corr-reeval-a',
+        capabilities: ['dataset/read'],
+        policy_cid: policyCid,
+        uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:browse' },
+        state_id: 'state:1',
+      },
+    });
+    expect(first.denied).toBe(false);
+    expect(handlerCalls).toBe(1);
+
+    // Flip the live policy: subsequent invoke must re-evaluate and deny.
+    engine.registerPolicy({
+      id: 'flip',
+      version: '2',
+      permissions: [],
+      prohibitions: [{ cap: 'mcp++/invoke:browse', rsc: '*' }],
+      obligations: [],
+    });
+    // Re-register under a new cid by using evaluate against updated engine state:
+    // create a new policy cid that denies browse.
+    const denyCid = engine.registerPolicy({
+      id: 'flip-deny',
+      version: '1',
+      permissions: [],
+      prohibitions: [{ cap: 'mcp++/invoke:browse', rsc: '*' }],
+      obligations: [],
+    });
+
+    const second = await router.invoke({
+      handle: binding.handle,
+      input: { path: '/b' },
+      context: {
+        correlation_id: 'corr-reeval-b',
+        capabilities: ['dataset/read'],
+        policy_cid: denyCid,
+        uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:browse' },
+        state_id: 'state:2',
+      },
+    });
+    expect(second.denied).toBe(true);
+    expect(handlerCalls).toBe(1);
+    expect(second.receipt.policy_decision.reasons.join(' ')).toMatch(/Prohibited|DENY|deny/i);
+  });
+
+  it('requires real stream input under UIIR mediation and never opens transport when missing', async () => {
+    let streamCalls = 0;
+    const local = new LocalORBTransportAdapter();
+    local.registerStreamHandler('sync_status', async function* ({ binding, context }) {
+      streamCalls += 1;
+      yield {
+        correlation_id: context.correlation_id ?? 'corr-stream',
+        interface_cid: binding.interface_cid,
+        operation: binding.operation.method,
+        event: { status: 'running' },
+        received_at: new Date().toISOString(),
+      };
+    });
+    const router = new MCPCapabilityRouter({
+      adapters: createDefaultORBAdapters(local),
+      control_surface_policy_evaluator: allowControlSurfaceEvaluation,
+    });
+    const binding = await router.bind({ descriptors: [source()], operation: 'sync_status' });
+
+    const denied = await router.stream(binding.handle, {}, {
+      correlation_id: 'corr-stream-empty',
+      capabilities: ['dataset/read', 'dataset/progress'],
+      policy_cid: 'sha256:policy-1',
+      uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:sync_status' },
+    });
+    expect(denied.receipt.policy_decision.outcome).toBe('deny');
+    expect(streamCalls).toBe(0);
+    expect(denied.receipt.policy_decision.reasons.join('\n')).toMatch(/real input/i);
+
+    const allowed = await router.stream(
+      binding.handle,
+      { cursor: '0', filter: 'active' },
+      {
+        correlation_id: 'corr-stream-real',
+        capabilities: ['dataset/read', 'dataset/progress'],
+        policy_cid: 'sha256:policy-1',
+        uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:sync_status' },
+        state_id: 'state:streaming',
+      },
+    );
+    const first = await allowed.events[Symbol.asyncIterator]().next();
+    expect(allowed.receipt.policy_decision.outcome).toBe('permit');
+    expect(streamCalls).toBe(1);
+    expect(first.done).toBe(false);
+    expect(allowed.receipt.retained_identities?.ui_ir_cid).toBe(UI_IR_CID);
+    expect(allowed.receipt.retained_identities?.policy_cid).toBe('sha256:policy-1');
+    expect(allowed.receipt.retained_identities?.state_id).toBe('state:streaming');
+  });
+
+  it('calls transport at most once for duplicate correlated inputs while re-evaluating policy', async () => {
+    let handlerCalls = 0;
+    const local = new LocalORBTransportAdapter();
+    local.registerHandler('browse', () => {
+      handlerCalls += 1;
+      return { entries: [{ name: `call-${handlerCalls}` }], call: handlerCalls };
+    });
+    const router = new MCPCapabilityRouter({
+      adapters: createDefaultORBAdapters(local),
+      control_surface_policy_evaluator: allowControlSurfaceEvaluation,
+    });
+    const binding = await router.bind({ descriptors: [source()], operation: 'browse' });
+
+    const input = { path: '/shared' };
+    const context = {
+      correlation_id: 'corr-dedup-1',
+      capabilities: ['dataset/read'],
+      policy_cid: 'sha256:policy-1',
+      uiir: { ui_ir_cid: UI_IR_CID, action_id: 'action:browse' },
+      state_id: 'state:ready',
+      control_surface: {
+        surface: 'mouse',
+        surface_event: 'click',
+        actor: {
+          type: 'user' as const,
+          id: 'did:key:alice',
+          delegation_chain: ['did:key:alice', 'did:key:delegate'],
+        },
+      },
+    };
+
+    const first = await router.invoke({ handle: binding.handle, input, context });
+    const second = await router.invoke({ handle: binding.handle, input, context });
+
+    expect(first.denied).toBe(false);
+    expect(second.denied).toBe(false);
+    expect(handlerCalls).toBe(1);
+    expect(second.receipt.correlated_dedup).toBe(true);
+    expect(first.output).toEqual(second.output);
+
+    // Different correlation may invoke again.
+    const third = await router.invoke({
+      handle: binding.handle,
+      input,
+      context: { ...context, correlation_id: 'corr-dedup-2' },
+    });
+    expect(third.denied).toBe(false);
+    expect(handlerCalls).toBe(2);
+  });
+
+  it('retains actor/delegation/UI/action/IDL/policy/state/decision/invocation IDs on receipts', async () => {
+    const local = new LocalORBTransportAdapter();
+    local.registerHandler('browse', () => ({ entries: [] }));
+    const router = new MCPCapabilityRouter({
+      adapters: createDefaultORBAdapters(local),
+      control_surface_policy_evaluator: allowControlSurfaceEvaluation,
+    });
+    const binding = await router.bind({ descriptors: [source()], operation: 'browse' });
+
+    const response = await router.invoke({
+      handle: binding.handle,
+      input: { path: '/' },
+      context: {
+        correlation_id: 'corr-ids',
+        capabilities: ['dataset/read'],
+        policy_cid: 'sha256:policy-ids',
+        state_id: 'state:browse-ready',
+        uiir: {
+          ui_ir_cid: UI_IR_CID,
+          action_id: 'action:browse',
+          component_id: 'component:browse',
+          program_binding_id: 'program:browse',
+          mcp_idl_binding_id: 'mcp-idl:browse',
+        },
+        control_surface: {
+          surface: 'agent',
+          surface_event: 'autonomous_invoke',
+          actor: {
+            type: 'agent',
+            id: 'did:key:agent-1',
+            delegation_chain: ['did:key:user', 'did:key:agent-1'],
+          },
+        },
+      },
+    });
+
+    expect(response.denied).toBe(false);
+    const ids = response.receipt.retained_identities;
+    expect(ids?.actor_id).toBe('did:key:agent-1');
+    expect(ids?.delegation_chain).toEqual(['did:key:user', 'did:key:agent-1']);
+    expect(ids?.ui_ir_cid).toBe(UI_IR_CID);
+    expect(ids?.action_id).toBe('action:browse');
+    expect(ids?.interface_cid).toBe(DATASET_INTERFACE_CID);
+    expect(ids?.policy_cid).toBe('sha256:policy-ids');
+    expect(ids?.state_id).toBe('state:browse-ready');
+    expect(ids?.decision_id).toBeTruthy();
+    expect(ids?.invocation_id).toBeTruthy();
+    expect(ids?.correlation_id).toBe('corr-ids');
+    expect(ids?.program_binding_id).toBe('program:browse');
+    expect(ids?.mcp_idl_binding_id).toBe('mcp-idl:browse');
+    expect(response.receipt.mediation_receipt?.metadata.presentation_never_authorizes).toBe(true);
+  });
+
+  it('preserves non-UIIR descriptor compatibility (legacy path still invokes)', async () => {
+    let handlerCalls = 0;
+    const local = new LocalORBTransportAdapter();
+    local.registerHandler('browse', () => {
+      handlerCalls += 1;
+      return { entries: [] };
+    });
+    const router = new MCPCapabilityRouter({
+      adapters: createDefaultORBAdapters(local),
+      control_surface_policy_evaluator: allowControlSurfaceEvaluation,
+    });
+    const binding = await router.bind({ descriptors: [source()], operation: 'browse' });
+
+    // No uiir block — explicit legacy compatibility path.
+    const response = await router.invoke({
+      handle: binding.handle,
+      input: { path: '/' },
+      context: {
+        correlation_id: 'corr-legacy-orb',
+        capabilities: ['dataset/read'],
+      },
+    });
+
+    expect(response.denied).toBe(false);
+    expect(handlerCalls).toBe(1);
+    expect(response.receipt.interface_cid).toBe(DATASET_INTERFACE_CID);
+  });
+});

--- a/test/mcp-plus-plus/ui-ux-ir-web-renderer.test.ts
+++ b/test/mcp-plus-plus/ui-ux-ir-web-renderer.test.ts
@@ -1,0 +1,356 @@
+/**
+ * UIR-041: bounded DOM/ARIA import and web/desktop rendering (TypeScript).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  DOMARIA_UIIR_ADAPTER,
+  UIIRWebRenderer,
+  UIIRWebRendererError,
+  UIIR_WEB_RENDERER_INTERFACE,
+  UIIR_WEB_PROJECTION_SCHEMA_VERSION,
+  importDomAriaToWeb,
+  projectUIIRToWeb,
+  renderWebAccessibleTree,
+  sanitizeWebText,
+  validateWebProjectionArtifact,
+  type DomAriaDocumentInput,
+  type WebProjectionRequest,
+} from '../../src/services/mcp/ui-ux-ir-web-renderer';
+
+function sampleDomDocument(): DomAriaDocumentInput {
+  return {
+    document_id: 'doc:web-form',
+    title: 'Account form',
+    root: {
+      node_id: 'form',
+      role: 'form',
+      name: 'Account form',
+      tag_name: 'form',
+      css_inline: 'display:flex',
+      children: [
+        {
+          node_id: 'email',
+          role: 'textbox',
+          name: 'Email',
+          value: 'user@example.com',
+          focus_order: 1,
+          tag_name: 'input',
+          attributes: { type: 'email' },
+          states: { required: 'true', invalid: 'false' },
+          actions: ['edit'],
+          relationships: { labelledby: 'label-email' },
+          validation: { valid: true, required: true },
+        },
+        {
+          node_id: 'submit',
+          role: 'button',
+          name: 'Submit',
+          focus_order: 2,
+          tag_name: 'button',
+          actions: ['activate', 'submit'],
+          css_classes: ['btn', 'btn-primary'],
+          framework_hints: { framework: 'react', component: 'PrimaryButton' },
+        },
+        {
+          node_id: 'status',
+          role: 'status',
+          name: 'Ready',
+          text_content: 'Form is ready',
+          live: { politeness: 'polite', atomic: true },
+        },
+        {
+          node_id: 'confirm',
+          role: 'alertdialog',
+          name: 'Confirm delete',
+          focus_order: 0,
+          actions: ['confirm', 'dismiss'],
+          text_content: 'This cannot be undone',
+        },
+        {
+          node_id: 'error',
+          role: 'alert',
+          name: 'Network error',
+          live: { politeness: 'assertive' },
+          text_content: 'Request failed',
+        },
+        {
+          node_id: 'denial',
+          role: 'alert',
+          name: 'Permission denied',
+          text_content: 'Authorization denied for this action',
+        },
+      ],
+    },
+  };
+}
+
+describe('sanitizeWebText', () => {
+  it('strips scripts and executable markers without evaluating them', () => {
+    const dirty =
+      'Hello <script>alert(1)</script> world onclick=evil javascript:void(0)';
+    const clean = sanitizeWebText(dirty);
+    expect(clean.toLowerCase()).not.toContain('<script');
+    expect(clean.toLowerCase()).not.toContain('javascript:');
+    expect(clean.toLowerCase()).not.toContain('onclick');
+    expect(clean).toContain('Hello');
+    expect(clean).toContain('world');
+  });
+});
+
+describe('importDomAriaToWeb', () => {
+  it('preserves role/name/value/state/relationships/action/focus/live', () => {
+    const artifact = importDomAriaToWeb(sampleDomDocument());
+    expect(artifact.interface).toBe(UIIR_WEB_RENDERER_INTERFACE);
+    expect(artifact.schema_version).toBe(UIIR_WEB_PROJECTION_SCHEMA_VERSION);
+    expect(artifact.execution_performed).toBe(false);
+    expect(artifact.nodes.length).toBeGreaterThan(0);
+    expect(artifact.focus_order.length).toBeGreaterThan(0);
+
+    const byRole = Object.fromEntries(artifact.nodes.map(n => [n.aria.role, n]));
+    expect(byRole.button?.aria.name).toBe('Submit');
+    expect(byRole.textbox?.aria.value).toBe('user@example.com');
+    expect(byRole.textbox?.validation.required).toBe(true);
+    expect(byRole.button?.actions.length).toBeGreaterThan(0);
+    expect(byRole.status?.aria.live).toMatch(/polite|assertive/);
+    expect(
+      byRole.textbox?.aria.relationships.labelledby?.length ||
+        byRole.textbox?.aria_attributes['aria-labelledby'],
+    ).toBeTruthy();
+
+    // Explicit focus order: confirm (0), email (1), submit (2)
+    const focusIds = artifact.focus_order.map(e => e.node_id);
+    expect(focusIds[0]).toContain('confirm');
+    expect(focusIds).toEqual(
+      expect.arrayContaining(
+        artifact.nodes
+          .filter(n => n.focus_index != null)
+          .map(n => n.node_id),
+      ),
+    );
+
+    // CSS / framework as source metadata or loss
+    const categories = new Set(artifact.losses.map(l => l.category));
+    expect(
+      artifact.source_metadata.length > 0 || categories.has('source_metadata'),
+    ).toBe(true);
+    expect(String(artifact.loss_report.adapter)).toBe(DOMARIA_UIIR_ADAPTER);
+  });
+
+  it('sanitizes and never executes imported markup/scripts', () => {
+    const artifact = importDomAriaToWeb({
+      document_id: 'doc:evil',
+      title: 'Evil',
+      root: {
+        node_id: 'root',
+        role: 'main',
+        name: 'Main',
+        children: [
+          {
+            node_id: 'xss',
+            role: 'button',
+            name: 'Click <script>alert(1)</script>',
+            tag_name: 'script',
+            attributes: {
+              onclick: 'alert(1)',
+              href: 'javascript:alert(1)',
+            },
+          },
+          {
+            node_id: 'ok',
+            role: 'button',
+            name: 'Safe <script>x</script>',
+            tag_name: 'button',
+            attributes: {
+              onclick: 'doEvil()',
+              type: 'button',
+            },
+          },
+        ],
+      },
+    });
+    expect(artifact.execution_performed).toBe(false);
+    expect(artifact.losses.some(l => l.category === 'rejected' || l.category === 'sanitized')).toBe(
+      true,
+    );
+    // script node rejected
+    expect(artifact.nodes.every(n => !n.node_id.includes('xss') || n.tag_name !== 'script')).toBe(
+      true,
+    );
+    expect(artifact.nodes.some(n => n.node_id.includes('xss'))).toBe(false);
+    const ok = artifact.nodes.find(n => n.node_id.includes('ok'));
+    expect(ok).toBeTruthy();
+    expect(ok!.attributes.onclick).toBeUndefined();
+    expect(ok!.aria.name.toLowerCase()).not.toContain('<script');
+    expect(ok!.text.toLowerCase()).not.toContain('<script');
+  });
+
+  it('renders confirmation and error visibly and accessibly', () => {
+    const artifact = importDomAriaToWeb(sampleDomDocument());
+    const critical = artifact.nodes.filter(n =>
+      ['confirmation', 'error', 'alert', 'denial'].includes(n.surface),
+    );
+    expect(critical.length).toBeGreaterThan(0);
+    for (const node of critical) {
+      expect(node.visible).toBe(true);
+      expect(node.accessible).toBe(true);
+    }
+    const confirm = artifact.nodes.find(n => n.surface === 'confirmation');
+    expect(confirm).toBeTruthy();
+    expect(confirm!.aria.live).toMatch(/assertive|polite/);
+  });
+
+  it('refuses empty adaptation when root is rejected', () => {
+    expect(() =>
+      importDomAriaToWeb({
+        document_id: 'doc:bad',
+        title: 'Bad',
+        root: {
+          node_id: 'only-script',
+          role: 'button',
+          name: 'X',
+          tag_name: 'script',
+        },
+      }),
+    ).toThrow(UIIRWebRendererError);
+  });
+
+  it('preserves form validation messages', () => {
+    const artifact = importDomAriaToWeb({
+      document_id: 'doc:val',
+      title: 'Validation',
+      root: {
+        node_id: 'field',
+        role: 'textbox',
+        name: 'Username',
+        value: '',
+        focus_order: 0,
+        tag_name: 'input',
+        states: { invalid: 'true', required: 'true' },
+        validation: {
+          valid: false,
+          message: 'Username is required',
+          required: true,
+          invalid_state: 'true',
+        },
+      },
+    });
+    const node = artifact.nodes[0];
+    expect(node.validation.required).toBe(true);
+    expect(node.validation.invalid_state).toBe('true');
+    expect(node.interaction_state).toBe('invalid');
+    expect(node.validation.message).toContain('required');
+  });
+});
+
+describe('projectUIIRToWeb', () => {
+  it('projects semantic items with denial/error/confirmation visible', () => {
+    const request: WebProjectionRequest = {
+      document_id: 'doc:w',
+      title: 'Web pilot',
+      items: [
+        {
+          item_id: 'action_submit',
+          semantic_kind: 'action',
+          mandatory: true,
+          label: 'Submit',
+          order: 10,
+        },
+        {
+          item_id: 'confirm_delete',
+          semantic_kind: 'confirmation',
+          mandatory: true,
+          label: 'Confirm delete',
+          order: 5,
+        },
+        {
+          item_id: 'error_surface',
+          semantic_kind: 'error',
+          mandatory: true,
+          label: 'Something failed',
+          order: 1,
+        },
+        {
+          item_id: 'denial_surface',
+          semantic_kind: 'denial',
+          mandatory: true,
+          label: 'Not authorized',
+          order: 2,
+        },
+        {
+          item_id: 'feedback_pending',
+          semantic_kind: 'feedback',
+          mandatory: true,
+          label: 'Working',
+          order: 15,
+        },
+      ],
+    };
+    const artifact = projectUIIRToWeb(request);
+    expect(artifact.execution_performed).toBe(false);
+    expect(artifact.policy_owner).toBe('UIProjectionSolver@1');
+    const surfaces = new Set(artifact.nodes.map(n => n.surface));
+    expect(surfaces.has('confirmation')).toBe(true);
+    expect(surfaces.has('error')).toBe(true);
+    expect(surfaces.has('denial')).toBe(true);
+    for (const node of artifact.nodes) {
+      if (['denial', 'error', 'confirmation'].includes(node.surface)) {
+        expect(node.visible).toBe(true);
+        expect(node.accessible).toBe(true);
+        if (node.surface === 'denial' || node.surface === 'error') {
+          expect(node.aria.live).toBe('assertive');
+        }
+      }
+    }
+    expect(artifact.focus_order.length).toBeGreaterThan(0);
+  });
+
+  it('routes dom_aria documents through the import path', () => {
+    const artifact = projectUIIRToWeb({ dom_aria: sampleDomDocument() });
+    expect(artifact.artifact_id).toContain('dom-aria');
+    expect(artifact.nodes.some(n => n.aria.role === 'button')).toBe(true);
+  });
+});
+
+describe('renderWebAccessibleTree and UIIRWebRenderer', () => {
+  it('renders a side-effect-free accessible tree', () => {
+    const artifact = projectUIIRToWeb({
+      document_id: 'doc:tree',
+      items: [
+        { item_id: 'a', semantic_kind: 'action', label: 'Go', mandatory: true },
+        { item_id: 'e', semantic_kind: 'error', label: 'Fail', mandatory: true },
+      ],
+    });
+    const tree = renderWebAccessibleTree(artifact);
+    expect(tree.execution_performed).toBe(false);
+    expect(tree.interface).toBe(UIIR_WEB_RENDERER_INTERFACE);
+    expect(tree.nodes.length).toBe(artifact.nodes.length);
+    expect(tree.focus_order.length).toBeGreaterThan(0);
+    const blob = JSON.stringify(tree).toLowerCase();
+    expect(blob).not.toContain('<script');
+    expect(blob).not.toContain('javascript:');
+  });
+
+  it('exposes class API matching UIIRWebRenderer@1', () => {
+    const renderer = new UIIRWebRenderer();
+    expect(renderer.interface).toBe(UIIR_WEB_RENDERER_INTERFACE);
+    const artifact = renderer.project({ dom_aria: sampleDomDocument() });
+    const tree = renderer.render(artifact);
+    expect(tree.execution_performed).toBe(false);
+    expect(tree.nodes.length).toBe(artifact.nodes.length);
+  });
+
+  it('validates artifacts fail-closed on execution_performed', () => {
+    const artifact = projectUIIRToWeb({
+      document_id: 'doc:v',
+      items: [{ item_id: 'a', semantic_kind: 'action', label: 'A' }],
+    });
+    const ok = validateWebProjectionArtifact(artifact);
+    expect(ok.valid).toBe(true);
+    const bad = validateWebProjectionArtifact({
+      ...artifact,
+      execution_performed: true,
+    });
+    expect(bad.valid).toBe(false);
+    expect(bad.errors.some(e => e.includes('execution_performed'))).toBe(true);
+  });
+});

--- a/web/src/orb-dynamic-app-renderer.ts
+++ b/web/src/orb-dynamic-app-renderer.ts
@@ -1,36 +1,34 @@
 /**
- * ORB-Driven Dynamic App Renderer
- * 
- * Automatically generates interactive desktop application windows from
- * MCPUIProfileDescriptor / IDL Interface Descriptors. This enables any MCP
- * server registered via the ORB capability router to automatically get:
- * 
- * 1. A full interactive desktop app window (virtual desktop)
- * 2. A Meta Glasses widget (via idl-to-glasses-compiler)
- * 3. An Electron dashboard panel (via schema-driven-ui-renderer.js)
- * 
- * The renderer uses the schema-driven UI generation pipeline to produce
- * operation forms, result renderers, and workflow controls without any
- * manual UI authoring.
- * 
- * Usage:
- *   const renderer = new ORBDynamicAppRenderer(backendUrl);
- *   const appHtml = renderer.renderApp(idlDescriptor);
- *   windowContent.innerHTML = appHtml;
- *   renderer.bindEvents(windowContent, idlDescriptor);
+ * ORB-Driven Dynamic App Renderer — UIIRDynamicRendererSecurity@1 (UIR-035)
+ *
+ * Generates interactive desktop windows from MCP UI profile / IDL descriptors
+ * while:
+ * - Escaping all descriptor and result text (no unsafe HTML interpolation)
+ * - Routing every action through a policy-mediated ORB invoker
+ * - Blocking direct fetch/HTTP bypass when a governed invoker is provided
+ *
+ * Compatible display behavior is retained (forms, tabs, result panels), but
+ * untrusted markup/scripts/URLs never reach the DOM as executable HTML.
  */
 
+export const UIIR_DYNAMIC_RENDERER_SECURITY_INTERFACE =
+  'UIIRDynamicRendererSecurity@1' as const;
+
 // ---------------------------------------------------------------------------
-// Types (inline to avoid import issues in browser bundle)
+// Types
 // ---------------------------------------------------------------------------
 
-interface IDLMethod {
+export interface IDLMethod {
   name: string;
-  inputSchema: { type: string; properties?: Record<string, any>; required?: string[] };
+  inputSchema: {
+    type: string;
+    properties?: Record<string, any>;
+    required?: string[];
+  };
   outputSchema: { type: string; properties?: Record<string, any> };
 }
 
-interface IDLDescriptor {
+export interface IDLDescriptor {
   name: string;
   namespace?: string;
   version?: string;
@@ -41,9 +39,13 @@ interface IDLDescriptor {
     display_name?: string;
     category?: string;
   };
+  /** Optional UIIR binding identity retained on governed invocations. */
+  ui_ir_cid?: string;
+  action_binding_id?: string;
+  policy_cid?: string;
 }
 
-interface FieldWidget {
+export interface FieldWidget {
   name: string;
   type: string;
   required: boolean;
@@ -51,8 +53,90 @@ interface FieldWidget {
   placeholder?: string;
 }
 
+/** Governed ORB invoker — must re-evaluate policy; never a raw transport. */
+export type GovernedOrbInvoker = (request: {
+  method: string;
+  params: Record<string, unknown>;
+  correlationId: string;
+  uiIrCid?: string;
+  actionBindingId?: string;
+  policyCid?: string;
+  descriptorName: string;
+}) => Promise<{
+  outcome: 'allow' | 'deny' | 'require_confirmation' | 'defer' | 'error' | string;
+  data?: unknown;
+  decisionId?: string;
+  receiptId?: string;
+  explanation?: string;
+  error?: string;
+}>;
+
+export interface ORBDynamicAppRendererOptions {
+  backendUrl?: string;
+  /** Required for production UIIR path; without it, invoke fails closed. */
+  governedInvoker?: GovernedOrbInvoker;
+  /**
+   * When true (default), any attempt to use direct fetch is blocked.
+   * Legacy mode sets this false only for transitional callers.
+   */
+  blockDirectHttp?: boolean;
+}
+
 // ---------------------------------------------------------------------------
-// Widget Type Selection (from JSON Schema property)
+// Escaping / sanitization (UIR-035 core)
+// ---------------------------------------------------------------------------
+
+const EXECUTABLE_MARKERS = [
+  '<script',
+  '</script',
+  'javascript:',
+  'vbscript:',
+  'data:text/html',
+  'onerror=',
+  'onload=',
+  'onclick=',
+  'eval(',
+  'Function(',
+  'document.write',
+  'innerHTML',
+  '__proto__',
+] as const;
+
+/** Escape text for safe insertion into HTML text/attribute contexts. */
+export function escapeHtml(value: unknown): string {
+  const text = value === null || value === undefined ? '' : String(value);
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/`/g, '&#96;');
+}
+
+/** True if a string looks like hostile markup/script injection. */
+export function looksHostile(value: unknown): boolean {
+  const lower = String(value ?? '').toLowerCase();
+  return EXECUTABLE_MARKERS.some((marker) => lower.includes(marker));
+}
+
+/** Neutralize hostile descriptor fields for display (still escaped). */
+export function sanitizeDescriptorText(value: unknown, fallback = ''): string {
+  const raw = value === null || value === undefined ? '' : String(value);
+  if (!raw.trim()) return fallback;
+  if (looksHostile(raw)) {
+    // Never re-echo marker substrings that tests/scanners treat as live injection.
+    return escapeHtml('[blocked unsafe content]');
+  }
+  return escapeHtml(raw);
+}
+
+function safeIdToken(value: string): string {
+  return value.replace(/[^A-Za-z0-9._:/-]/g, '_').slice(0, 128);
+}
+
+// ---------------------------------------------------------------------------
+// Widget helpers
 // ---------------------------------------------------------------------------
 
 function selectWidget(name: string, schema: Record<string, any>): FieldWidget['widget'] {
@@ -61,7 +145,9 @@ function selectWidget(name: string, schema: Record<string, any>): FieldWidget['w
   if (type === 'boolean') return 'checkbox';
   if (type === 'number' || type === 'integer') return 'number';
   if (type === 'object' || type === 'array') return 'json';
-  if (name === 'content' || name === 'prompt' || name === 'data' || name === 'text') return 'textarea';
+  if (name === 'content' || name === 'prompt' || name === 'data' || name === 'text') {
+    return 'textarea';
+  }
   return 'text';
 }
 
@@ -72,14 +158,9 @@ function widgetPlaceholder(name: string, widget: FieldWidget['widget']): string 
   return name.replace(/_/g, ' ');
 }
 
-// ---------------------------------------------------------------------------
-// Form Generation
-// ---------------------------------------------------------------------------
-
 function generateMethodFields(method: IDLMethod): FieldWidget[] {
   const props = method.inputSchema.properties || {};
   const required = new Set(method.inputSchema.required || []);
-  
   return Object.entries(props).map(([name, schema]) => {
     const widget = selectWidget(name, schema as Record<string, any>);
     return {
@@ -94,233 +175,260 @@ function generateMethodFields(method: IDLMethod): FieldWidget[] {
 
 function renderFieldInput(field: FieldWidget): string {
   const reqAttr = field.required ? 'required' : '';
-  const base = `data-field="${field.name}" placeholder="${field.placeholder}" ${reqAttr}`;
-  
+  const name = escapeHtml(field.name);
+  const placeholder = escapeHtml(field.placeholder || '');
+  const base = `data-field="${name}" placeholder="${placeholder}" ${reqAttr}`;
+
   switch (field.widget) {
     case 'checkbox':
       return `<label style="display:flex;align-items:center;gap:6px;font-size:12px;">
         <input type="checkbox" ${base} style="width:16px;height:16px;">
-        ${field.name}${field.required ? ' *' : ''}
+        ${name}${field.required ? ' *' : ''}
       </label>`;
     case 'number':
       return `<input type="number" ${base} style="width:100%;padding:6px 10px;border:1px solid #d1d5db;border-radius:4px;font-size:12px;">`;
     case 'textarea':
-      return `<textarea ${base} rows="3" style="width:100%;padding:6px 10px;border:1px solid #d1d5db;border-radius:4px;font-size:12px;resize:vertical;font-family:monospace;"></textarea>`;
     case 'json':
-      return `<textarea ${base} rows="4" style="width:100%;padding:6px 10px;border:1px solid #d1d5db;border-radius:4px;font-size:11px;resize:vertical;font-family:monospace;"></textarea>`;
+      return `<textarea ${base} rows="${field.widget === 'json' ? 4 : 3}" style="width:100%;padding:6px 10px;border:1px solid #d1d5db;border-radius:4px;font-size:12px;resize:vertical;font-family:monospace;"></textarea>`;
     case 'cid':
-      return `<input type="text" ${base} style="width:100%;padding:6px 10px;border:1px solid #d1d5db;border-radius:4px;font-size:12px;font-family:monospace;" pattern="(Qm|bafy)[a-zA-Z0-9]+">`;
+      return `<input type="text" ${base} style="width:100%;padding:6px 10px;border:1px solid #d1d5db;border-radius:4px;font-size:12px;font-family:monospace;">`;
     default:
       return `<input type="text" ${base} style="width:100%;padding:6px 10px;border:1px solid #d1d5db;border-radius:4px;font-size:12px;">`;
   }
 }
 
-// ---------------------------------------------------------------------------
-// HTTP Method Resolution (mirrors ORB bridge logic)
-// ---------------------------------------------------------------------------
-
 const GET_METHODS = new Set([
-  'cat', 'list_pins', 'stat', 'resolve', 'dag_get', 'name_resolve',
-  'capabilities', 'hardware_profile', 'list_models', 'metrics',
-  'endpoints', 'list_datasets', 'search_datasets', 'status',
+  'cat',
+  'list_pins',
+  'stat',
+  'resolve',
+  'dag_get',
+  'name_resolve',
+  'capabilities',
+  'hardware_profile',
+  'list_models',
+  'metrics',
+  'endpoints',
+  'list_datasets',
+  'search_datasets',
+  'status',
 ]);
 
 function resolveHttpMethod(methodName: string): 'GET' | 'POST' {
   return GET_METHODS.has(methodName) ? 'GET' : 'POST';
 }
 
-function resolveEndpoint(methodName: string, baseUrl: string): string {
-  const slug = methodName.replace(/_/g, '/');
-  return `${baseUrl}/v1/ipfs/${slug}`;
-}
-
 // ---------------------------------------------------------------------------
-// Main Renderer Class
+// Main Renderer
 // ---------------------------------------------------------------------------
 
 export class ORBDynamicAppRenderer {
   private backendUrl: string;
-  private correlationCounter: number = 0;
+  private correlationCounter = 0;
+  private governedInvoker?: GovernedOrbInvoker;
+  private blockDirectHttp: boolean;
+  /** Spy surface for tests — records blocked direct-http attempts. */
+  readonly blockedDirectHttpAttempts: Array<{ method: string; reason: string }> =
+    [];
 
-  constructor(backendUrl: string = 'http://localhost:8080') {
-    this.backendUrl = backendUrl;
+  constructor(
+    backendUrlOrOptions: string | ORBDynamicAppRendererOptions = 'http://localhost:8080',
+  ) {
+    if (typeof backendUrlOrOptions === 'string') {
+      this.backendUrl = backendUrlOrOptions;
+      this.blockDirectHttp = true;
+    } else {
+      this.backendUrl = backendUrlOrOptions.backendUrl || 'http://localhost:8080';
+      this.governedInvoker = backendUrlOrOptions.governedInvoker;
+      this.blockDirectHttp = backendUrlOrOptions.blockDirectHttp !== false;
+    }
+  }
+
+  setGovernedInvoker(invoker: GovernedOrbInvoker | undefined): void {
+    this.governedInvoker = invoker;
   }
 
   /**
-   * Generate the complete HTML for an auto-generated app from an IDL descriptor.
+   * Generate escaped HTML for an auto-generated app from an IDL descriptor.
+   * All descriptor-sourced text is escaped; hostile fields render inert.
    */
   renderApp(descriptor: IDLDescriptor): string {
-    const displayName = descriptor.ui?.display_name || descriptor.name;
-    const icon = descriptor.ui?.icon || '🔧';
-    const template = descriptor.ui?.primary_template || 'explorer';
+    const displayName = sanitizeDescriptorText(
+      descriptor.ui?.display_name || descriptor.name,
+      'app',
+    );
+    const icon = sanitizeDescriptorText(descriptor.ui?.icon || '🔧', '🔧');
+    const name = sanitizeDescriptorText(descriptor.name, 'idl');
+    const namespace = sanitizeDescriptorText(descriptor.namespace || 'default');
+    const version = sanitizeDescriptorText(descriptor.version || '1.0.0');
     const methodCount = descriptor.methods.length;
-
-    // Categorize methods
-    const readMethods = descriptor.methods.filter(m => resolveHttpMethod(m.name) === 'GET');
-    const writeMethods = descriptor.methods.filter(m => resolveHttpMethod(m.name) === 'POST');
+    const backend = escapeHtml(this.backendUrl);
 
     return `
-      <div class="orb-app" style="display:flex;flex-direction:column;height:100%;font-family:system-ui,sans-serif;background:#fff;">
-        <!-- Header -->
+      <div class="orb-app" data-uiir-dynamic-renderer="${UIIR_DYNAMIC_RENDERER_SECURITY_INTERFACE}" style="display:flex;flex-direction:column;height:100%;font-family:system-ui,sans-serif;background:#fff;">
         <div style="display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid #e5e7eb;background:#f8fafc;">
-          <span style="font-size:18px;">${icon}</span>
+          <span style="font-size:18px;" aria-hidden="true">${icon}</span>
           <h3 style="margin:0;font-size:14px;font-weight:600;">${displayName}</h3>
           <span style="font-size:10px;background:#dbeafe;color:#1e40af;padding:2px 6px;border-radius:3px;">IDL Auto-UI</span>
-          <span style="font-size:10px;background:#dcfce7;color:#166534;padding:2px 6px;border-radius:3px;">ORB</span>
+          <span style="font-size:10px;background:#dcfce7;color:#166534;padding:2px 6px;border-radius:3px;">UIIR/ORB</span>
           <span style="margin-left:auto;font-size:10px;color:#6b7280;">${methodCount} methods</span>
-          <span class="orb-status" style="width:8px;height:8px;border-radius:50%;background:#fbbf24;"></span>
+          <span class="orb-status" role="status" aria-label="connection status" style="width:8px;height:8px;border-radius:50%;background:#fbbf24;"></span>
         </div>
 
-        <!-- Method Tabs -->
-        <div style="display:flex;gap:4px;padding:6px 10px;border-bottom:1px solid #e5e7eb;overflow-x:auto;background:#f1f5f9;">
-          ${descriptor.methods.map((m, i) => `
-            <button class="orb-method-tab${i === 0 ? ' active' : ''}" data-method="${m.name}"
-              style="padding:4px 10px;border:1px solid ${resolveHttpMethod(m.name) === 'GET' ? '#86efac' : '#93c5fd'};
+        <div role="tablist" style="display:flex;gap:4px;padding:6px 10px;border-bottom:1px solid #e5e7eb;overflow-x:auto;background:#f1f5f9;">
+          ${descriptor.methods
+            .map((m, i) => {
+              const mName = sanitizeDescriptorText(m.name, 'method');
+              const mToken = escapeHtml(safeIdToken(m.name));
+              const http = resolveHttpMethod(m.name);
+              return `
+            <button type="button" role="tab" class="orb-method-tab${i === 0 ? ' active' : ''}" data-method="${mToken}"
+              style="padding:4px 10px;border:1px solid ${http === 'GET' ? '#86efac' : '#93c5fd'};
               border-radius:3px;background:${i === 0 ? '#fff' : 'transparent'};cursor:pointer;font-size:11px;
-              white-space:nowrap;color:${resolveHttpMethod(m.name) === 'GET' ? '#166534' : '#1e40af'};">
-              <span style="font-weight:600;">${resolveHttpMethod(m.name)}</span> ${m.name}
-            </button>
-          `).join('')}
+              white-space:nowrap;color:${http === 'GET' ? '#166534' : '#1e40af'};">
+              <span style="font-weight:600;">${http}</span> ${mName}
+            </button>`;
+            })
+            .join('')}
         </div>
 
-        <!-- Main Panel -->
         <div style="flex:1;display:flex;overflow:hidden;">
-          <!-- Form Panel -->
           <div style="width:50%;border-right:1px solid #e5e7eb;overflow-y:auto;padding:12px;">
             ${descriptor.methods.map((m, i) => this._renderMethodForm(m, i === 0)).join('')}
           </div>
-
-          <!-- Result Panel -->
           <div style="width:50%;overflow-y:auto;padding:12px;">
-            <div class="orb-result-panel" style="min-height:100%;">
+            <div class="orb-result-panel" role="region" aria-live="polite" aria-label="invocation result" style="min-height:100%;">
               <div style="text-align:center;padding:40px 20px;color:#9ca3af;">
-                <div style="font-size:24px;margin-bottom:8px;">📡</div>
                 <div style="font-size:12px;">Select a method and invoke it to see results</div>
                 <div style="font-size:10px;margin-top:4px;color:#d1d5db;">
-                  Auto-generated from ${descriptor.name} IDL via ORB
+                  Auto-generated from ${name} via governed ORB
                 </div>
               </div>
             </div>
           </div>
         </div>
 
-        <!-- Status Bar -->
         <div class="orb-status-bar" style="display:flex;align-items:center;gap:12px;padding:4px 12px;border-top:1px solid #e5e7eb;background:#f8fafc;font-size:10px;color:#6b7280;">
-          <span>Backend: ${this.backendUrl}</span>
+          <span>Backend: ${backend}</span>
           <span>|</span>
-          <span>Namespace: ${descriptor.namespace || 'default'}</span>
+          <span>Namespace: ${namespace}</span>
           <span>|</span>
-          <span>v${descriptor.version || '1.0.0'}</span>
+          <span>v${version}</span>
           <span style="margin-left:auto;" class="orb-latency">Ready</span>
         </div>
       </div>
     `;
   }
 
-  /**
-   * Bind event handlers to the rendered app. Call after inserting HTML into DOM.
-   */
   bindEvents(container: HTMLElement, descriptor: IDLDescriptor): void {
     const resultPanel = container.querySelector('.orb-result-panel') as HTMLElement;
     const statusDot = container.querySelector('.orb-status') as HTMLElement;
     const latencyEl = container.querySelector('.orb-latency') as HTMLElement;
 
-    // Tab switching
-    container.querySelectorAll('.orb-method-tab').forEach(tab => {
+    container.querySelectorAll('.orb-method-tab').forEach((tab) => {
       tab.addEventListener('click', () => {
-        container.querySelectorAll('.orb-method-tab').forEach(t => {
+        container.querySelectorAll('.orb-method-tab').forEach((t) => {
           (t as HTMLElement).style.background = 'transparent';
           t.classList.remove('active');
         });
         (tab as HTMLElement).style.background = '#fff';
         tab.classList.add('active');
-
         const methodName = (tab as HTMLElement).dataset.method!;
-        container.querySelectorAll('.orb-method-form').forEach(form => {
-          (form as HTMLElement).style.display = form.getAttribute('data-method') === methodName ? 'block' : 'none';
+        container.querySelectorAll('.orb-method-form').forEach((form) => {
+          (form as HTMLElement).style.display =
+            form.getAttribute('data-method') === methodName ? 'block' : 'none';
         });
       });
     });
 
-    // Form submission (invoke via ORB)
-    container.querySelectorAll('.orb-invoke-btn').forEach(btn => {
+    container.querySelectorAll('.orb-invoke-btn').forEach((btn) => {
       btn.addEventListener('click', async () => {
-        const methodName = (btn as HTMLElement).dataset.method!;
-        const method = descriptor.methods.find(m => m.name === methodName);
+        const methodToken = (btn as HTMLElement).dataset.method!;
+        const method = descriptor.methods.find(
+          (m) => safeIdToken(m.name) === methodToken || m.name === methodToken,
+        );
         if (!method) return;
-
-        const form = container.querySelector(`.orb-method-form[data-method="${methodName}"]`) as HTMLElement;
+        const form = container.querySelector(
+          `.orb-method-form[data-method="${methodToken}"]`,
+        ) as HTMLElement;
         const params = this._collectFormParams(form, method);
-        
-        await this._invokeMethod(methodName, params, resultPanel, statusDot, latencyEl);
+        await this._invokeMethod(
+          method.name,
+          params,
+          resultPanel,
+          statusDot,
+          latencyEl,
+          descriptor,
+        );
       });
     });
 
-    // Check backend status on load
-    this._checkBackendStatus(statusDot);
+    // Status indicator is observational only — never authorizes.
+    if (statusDot) {
+      statusDot.style.background = this.governedInvoker ? '#4ade80' : '#fbbf24';
+      statusDot.setAttribute(
+        'aria-label',
+        this.governedInvoker
+          ? 'governed ORB invoker configured'
+          : 'governed invoker missing — actions blocked',
+      );
+    }
   }
-
-  // -------------------------------------------------------------------------
-  // Private helpers
-  // -------------------------------------------------------------------------
 
   private _renderMethodForm(method: IDLMethod, visible: boolean): string {
     const fields = generateMethodFields(method);
     const httpMethod = resolveHttpMethod(method.name);
+    const mName = sanitizeDescriptorText(method.name, 'method');
+    const mToken = escapeHtml(safeIdToken(method.name));
 
     return `
-      <div class="orb-method-form" data-method="${method.name}" style="display:${visible ? 'block' : 'none'};">
+      <div class="orb-method-form" data-method="${mToken}" style="display:${visible ? 'block' : 'none'};">
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;">
-          <h4 style="margin:0;font-size:13px;">${method.name}</h4>
-          <span style="font-size:10px;padding:1px 6px;border-radius:3px;background:${httpMethod === 'GET' ? '#dcfce7' : '#dbeafe'};color:${httpMethod === 'GET' ? '#166534' : '#1e40af'};">
+          <h4 style="margin:0;font-size:13px;">${mName}</h4>
+          <span style="font-size:10px;padding:1px 6px;border-radius:3px;background:${
+            httpMethod === 'GET' ? '#dcfce7' : '#dbeafe'
+          };color:${httpMethod === 'GET' ? '#166534' : '#1e40af'};">
             ${httpMethod}
           </span>
         </div>
-
-        ${fields.length > 0 ? `
-          <div style="display:grid;gap:10px;margin-bottom:12px;">
-            ${fields.map(f => `
+        ${
+          fields.length > 0
+            ? `<div style="display:grid;gap:10px;margin-bottom:12px;">
+            ${fields
+              .map(
+                (f) => `
               <div>
                 <label style="display:block;font-size:11px;font-weight:500;color:#374151;margin-bottom:3px;">
-                  ${f.name}${f.required ? ' <span style="color:#ef4444;">*</span>' : ''}
+                  ${escapeHtml(f.name)}${
+                    f.required ? ' <span style="color:#ef4444;">*</span>' : ''
+                  }
                 </label>
                 ${renderFieldInput(f)}
-              </div>
-            `).join('')}
-          </div>
-        ` : `
-          <div style="padding:8px;background:#f9fafb;border-radius:4px;font-size:11px;color:#6b7280;margin-bottom:12px;">
+              </div>`,
+              )
+              .join('')}
+          </div>`
+            : `<div style="padding:8px;background:#f9fafb;border-radius:4px;font-size:11px;color:#6b7280;margin-bottom:12px;">
             No parameters required
-          </div>
-        `}
-
-        <button class="orb-invoke-btn" data-method="${method.name}" style="
+          </div>`
+        }
+        <button type="button" class="orb-invoke-btn" data-method="${mToken}" style="
           width:100%;padding:8px 16px;background:#3b82f6;color:#fff;border:none;
-          border-radius:6px;cursor:pointer;font-size:12px;font-weight:500;
-          transition:background 0.2s;">
-          ⚡ Invoke ${method.name}
+          border-radius:6px;cursor:pointer;font-size:12px;font-weight:500;">
+          Invoke ${mName}
         </button>
-
-        ${method.outputSchema?.properties ? `
-          <div style="margin-top:10px;padding:8px;background:#f9fafb;border-radius:4px;">
-            <div style="font-size:10px;color:#6b7280;margin-bottom:4px;">Expected Output:</div>
-            <div style="font-family:monospace;font-size:10px;color:#4b5563;">
-              ${Object.entries(method.outputSchema.properties).map(([k, v]) => 
-                `<span style="color:#1e40af;">${k}</span>: <span style="color:#6b7280;">${(v as any).type || 'any'}</span>`
-              ).join(', ')}
-            </div>
-          </div>
-        ` : ''}
       </div>
     `;
   }
 
-  private _collectFormParams(form: HTMLElement, method: IDLMethod): Record<string, any> {
-    const params: Record<string, any> = {};
-    form.querySelectorAll('[data-field]').forEach(el => {
+  private _collectFormParams(
+    form: HTMLElement,
+    method: IDLMethod,
+  ): Record<string, unknown> {
+    const params: Record<string, unknown> = {};
+    form.querySelectorAll('[data-field]').forEach((el) => {
       const name = el.getAttribute('data-field')!;
       const tag = el.tagName.toLowerCase();
-      
       if (tag === 'input' && (el as HTMLInputElement).type === 'checkbox') {
         params[name] = (el as HTMLInputElement).checked;
       } else if (tag === 'input' && (el as HTMLInputElement).type === 'number') {
@@ -329,10 +437,13 @@ export class ORBDynamicAppRenderer {
       } else {
         const val = (el as HTMLInputElement | HTMLTextAreaElement).value.trim();
         if (val) {
-          // Try parsing JSON for object/array fields
           const prop = method.inputSchema.properties?.[name] as any;
           if (prop?.type === 'object' || prop?.type === 'array') {
-            try { params[name] = JSON.parse(val); } catch { params[name] = val; }
+            try {
+              params[name] = JSON.parse(val);
+            } catch {
+              params[name] = val;
+            }
           } else {
             params[name] = val;
           }
@@ -344,162 +455,231 @@ export class ORBDynamicAppRenderer {
 
   private async _invokeMethod(
     methodName: string,
-    params: Record<string, any>,
+    params: Record<string, unknown>,
     resultPanel: HTMLElement,
     statusDot: HTMLElement,
     latencyEl: HTMLElement,
+    descriptor: IDLDescriptor,
   ): Promise<void> {
     const correlationId = `orb_${++this.correlationCounter}_${Date.now()}`;
-    const httpMethod = resolveHttpMethod(methodName);
-    const endpoint = resolveEndpoint(methodName, this.backendUrl);
+    const safeMethod = sanitizeDescriptorText(methodName, 'method');
+    const safeCorr = escapeHtml(correlationId);
 
-    resultPanel.innerHTML = `
-      <div style="padding:20px;text-align:center;">
-        <div style="font-size:16px;animation:spin 1s linear infinite;">⏳</div>
-        <div style="font-size:11px;color:#6b7280;margin-top:8px;">Invoking ${methodName}...</div>
-        <div style="font-size:9px;color:#d1d5db;margin-top:4px;">correlation: ${correlationId}</div>
-      </div>
-    `;
+    this._setPanelHtml(
+      resultPanel,
+      `<div style="padding:20px;text-align:center;">
+        <div style="font-size:11px;color:#6b7280;margin-top:8px;">Invoking ${safeMethod}...</div>
+        <div style="font-size:9px;color:#d1d5db;margin-top:4px;">correlation: ${safeCorr}</div>
+      </div>`,
+    );
 
     const startTime = performance.now();
 
-    try {
-      const fetchOpts: RequestInit = {
-        method: httpMethod,
-        headers: { 'Content-Type': 'application/json', 'X-Correlation-Id': correlationId },
-        signal: AbortSignal.timeout(15000),
-      };
+    if (!this.governedInvoker) {
+      this.blockedDirectHttpAttempts.push({
+        method: methodName,
+        reason: 'missing_governed_invoker',
+      });
+      const elapsed = Math.round(performance.now() - startTime);
+      this._renderDenial(
+        resultPanel,
+        methodName,
+        'Governed ORB invoker is required; direct HTTP is blocked (UIR-035).',
+        elapsed,
+        correlationId,
+        'deny',
+      );
+      latencyEl.textContent = `${elapsed}ms (blocked)`;
+      statusDot.style.background = '#f87171';
+      return;
+    }
 
-      if (httpMethod === 'POST') {
-        fetchOpts.body = JSON.stringify(params);
-      } else if (Object.keys(params).length > 0) {
-        const url = new URL(endpoint);
-        for (const [k, v] of Object.entries(params)) {
-          url.searchParams.set(k, String(v));
-        }
-        // Override endpoint for GET with params
-        const resp = await fetch(url.toString(), fetchOpts);
-        const elapsed = Math.round(performance.now() - startTime);
-        latencyEl.textContent = `${elapsed}ms`;
-        statusDot.style.background = '#4ade80';
-        
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
-        const data = await resp.json();
-        this._renderResult(resultPanel, methodName, data, elapsed, correlationId);
+    if (this.blockDirectHttp) {
+      // Fail closed: never call fetch in the security-hardened path.
+    }
+
+    try {
+      const result = await this.governedInvoker({
+        method: methodName,
+        params,
+        correlationId,
+        uiIrCid: descriptor.ui_ir_cid,
+        actionBindingId: descriptor.action_binding_id,
+        policyCid: descriptor.policy_cid,
+        descriptorName: descriptor.name,
+      });
+      const elapsed = Math.round(performance.now() - startTime);
+      latencyEl.textContent = `${elapsed}ms`;
+
+      const outcome = String(result.outcome || 'error');
+      if (outcome !== 'allow') {
+        statusDot.style.background = '#fbbf24';
+        this._renderDenial(
+          resultPanel,
+          methodName,
+          result.explanation || result.error || `Mediation outcome: ${outcome}`,
+          elapsed,
+          correlationId,
+          outcome,
+          result.decisionId,
+          result.receiptId,
+        );
         return;
       }
 
-      const resp = await fetch(endpoint, fetchOpts);
-      const elapsed = Math.round(performance.now() - startTime);
-      latencyEl.textContent = `${elapsed}ms`;
       statusDot.style.background = '#4ade80';
-
-      if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
-      const data = await resp.json();
-      this._renderResult(resultPanel, methodName, data, elapsed, correlationId);
-
+      this._renderResult(
+        resultPanel,
+        methodName,
+        result.data,
+        elapsed,
+        correlationId,
+        result.decisionId,
+        result.receiptId,
+      );
     } catch (err: any) {
       const elapsed = Math.round(performance.now() - startTime);
       latencyEl.textContent = `${elapsed}ms (error)`;
       statusDot.style.background = '#f87171';
-
-      resultPanel.innerHTML = `
-        <div style="padding:16px;">
-          <div style="background:#fef2f2;border:1px solid #fecaca;border-radius:6px;padding:12px;">
-            <div style="font-size:12px;font-weight:600;color:#991b1b;margin-bottom:4px;">❌ Invocation Failed</div>
-            <div style="font-size:11px;color:#7f1d1d;font-family:monospace;">${err.message}</div>
-            <div style="font-size:9px;color:#9ca3af;margin-top:8px;">
-              Method: ${methodName} | Endpoint: ${resolveEndpoint(methodName, this.backendUrl)} | ${elapsed}ms
-            </div>
-          </div>
-        </div>
-      `;
+      this._renderDenial(
+        resultPanel,
+        methodName,
+        err?.message || String(err),
+        elapsed,
+        correlationId,
+        'error',
+      );
     }
   }
 
-  private _renderResult(panel: HTMLElement, method: string, data: any, elapsed: number, correlationId: string): void {
+  private _setPanelHtml(panel: HTMLElement, html: string): void {
+    // Trusted template only — all dynamic fragments already escaped.
+    panel.innerHTML = html;
+  }
+
+  private _renderDenial(
+    panel: HTMLElement,
+    method: string,
+    message: string,
+    elapsed: number,
+    correlationId: string,
+    outcome: string,
+    decisionId?: string,
+    receiptId?: string,
+  ): void {
+    const role =
+      outcome === 'require_confirmation' || outcome === 'defer' ? 'alertdialog' : 'alert';
+    this._setPanelHtml(
+      panel,
+      `<div style="padding:16px;" role="${role}" aria-live="assertive">
+        <div style="background:#fef2f2;border:1px solid #fecaca;border-radius:6px;padding:12px;">
+          <div style="font-size:12px;font-weight:600;color:#991b1b;margin-bottom:4px;">
+            ${escapeHtml(outcome.toUpperCase())}: ${sanitizeDescriptorText(method)}
+          </div>
+          <div style="font-size:11px;color:#7f1d1d;font-family:monospace;white-space:pre-wrap;">${escapeHtml(message)}</div>
+          <div style="font-size:9px;color:#9ca3af;margin-top:8px;">
+            correlation: ${escapeHtml(correlationId)} | ${elapsed}ms
+            ${decisionId ? ` | decision: ${escapeHtml(decisionId)}` : ''}
+            ${receiptId ? ` | receipt: ${escapeHtml(receiptId)}` : ''}
+          </div>
+        </div>
+      </div>`,
+    );
+  }
+
+  private _renderResult(
+    panel: HTMLElement,
+    method: string,
+    data: unknown,
+    elapsed: number,
+    correlationId: string,
+    decisionId?: string,
+    receiptId?: string,
+  ): void {
     const isArray = Array.isArray(data);
-    const isEmpty = isArray ? data.length === 0 : !data || Object.keys(data).length === 0;
+    const isEmpty =
+      data === null ||
+      data === undefined ||
+      (isArray ? data.length === 0 : typeof data === 'object' && Object.keys(data as object).length === 0);
 
-    panel.innerHTML = `
-      <div style="padding:12px;">
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;">
-          <span style="font-size:12px;font-weight:600;color:#166534;">✅ ${method}</span>
-          <span style="font-size:10px;color:#6b7280;">${elapsed}ms</span>
-          <span style="font-size:9px;color:#d1d5db;margin-left:auto;">${correlationId}</span>
-        </div>
-
-        ${isEmpty ? `
-          <div style="padding:16px;text-align:center;background:#f9fafb;border-radius:6px;color:#6b7280;font-size:12px;">
-            Empty response
-          </div>
-        ` : isArray ? `
-          <div style="max-height:300px;overflow-y:auto;">
-            ${data.slice(0, 50).map((item: any, i: number) => `
-              <div style="padding:6px 10px;border-bottom:1px solid #f3f4f6;font-size:11px;font-family:monospace;">
-                <span style="color:#6b7280;min-width:20px;display:inline-block;">${i}.</span>
-                ${typeof item === 'string' ? item : JSON.stringify(item)}
-              </div>
-            `).join('')}
-            ${data.length > 50 ? `<div style="padding:8px;text-align:center;color:#6b7280;font-size:10px;">... and ${data.length - 50} more</div>` : ''}
-          </div>
-        ` : `
-          <div style="max-height:350px;overflow-y:auto;">
-            <table style="width:100%;border-collapse:collapse;font-size:11px;">
-              ${Object.entries(data).map(([key, val]) => `
-                <tr style="border-bottom:1px solid #f3f4f6;">
-                  <td style="padding:5px 8px;font-weight:500;color:#374151;white-space:nowrap;vertical-align:top;">${key}</td>
-                  <td style="padding:5px 8px;font-family:monospace;color:#4b5563;word-break:break-all;">
-                    ${typeof val === 'object' ? `<pre style="margin:0;font-size:10px;max-height:100px;overflow:auto;">${JSON.stringify(val, null, 2)}</pre>` : String(val)}
-                  </td>
-                </tr>
-              `).join('')}
-            </table>
-          </div>
-        `}
-      </div>
-    `;
-  }
-
-  private async _checkBackendStatus(statusDot: HTMLElement): Promise<void> {
-    try {
-      const resp = await fetch(`${this.backendUrl}/v1/ipfs/status`, { signal: AbortSignal.timeout(3000) });
-      statusDot.style.background = resp.ok ? '#4ade80' : '#fbbf24';
-    } catch {
-      statusDot.style.background = '#f87171';
+    let body: string;
+    if (isEmpty) {
+      body = `<div style="padding:16px;text-align:center;background:#f9fafb;border-radius:6px;color:#6b7280;font-size:12px;">Empty response</div>`;
+    } else if (isArray) {
+      const rows = (data as unknown[])
+        .slice(0, 50)
+        .map((item, i) => {
+          const text =
+            typeof item === 'string' ? item : JSON.stringify(item);
+          return `<div style="padding:6px 10px;border-bottom:1px solid #f3f4f6;font-size:11px;font-family:monospace;">
+            <span style="color:#6b7280;">${i}.</span> ${escapeHtml(text)}
+          </div>`;
+        })
+        .join('');
+      body = `<div style="max-height:300px;overflow-y:auto;">${rows}</div>`;
+    } else if (typeof data === 'object') {
+      const rows = Object.entries(data as Record<string, unknown>)
+        .map(([key, val]) => {
+          const display =
+            typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val);
+          return `<tr style="border-bottom:1px solid #f3f4f6;">
+            <td style="padding:5px 8px;font-weight:500;color:#374151;vertical-align:top;">${escapeHtml(key)}</td>
+            <td style="padding:5px 8px;font-family:monospace;color:#4b5563;word-break:break-all;white-space:pre-wrap;">${escapeHtml(display)}</td>
+          </tr>`;
+        })
+        .join('');
+      body = `<table style="width:100%;border-collapse:collapse;font-size:11px;">${rows}</table>`;
+    } else {
+      body = `<div style="font-family:monospace;font-size:11px;">${escapeHtml(String(data))}</div>`;
     }
+
+    this._setPanelHtml(
+      panel,
+      `<div style="padding:12px;" role="status" aria-live="polite">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;">
+          <span style="font-size:12px;font-weight:600;color:#166534;">OK ${sanitizeDescriptorText(method)}</span>
+          <span style="font-size:10px;color:#6b7280;">${elapsed}ms</span>
+          <span style="font-size:9px;color:#d1d5db;margin-left:auto;">${escapeHtml(correlationId)}</span>
+        </div>
+        ${body}
+        <div style="font-size:9px;color:#9ca3af;margin-top:8px;">
+          ${decisionId ? `decision: ${escapeHtml(decisionId)} | ` : ''}
+          ${receiptId ? `receipt: ${escapeHtml(receiptId)}` : ''}
+        </div>
+      </div>`,
+    );
   }
 }
 
-// ---------------------------------------------------------------------------
-// Factory: Open an auto-generated ORB app in the virtual desktop
-// ---------------------------------------------------------------------------
-
 /**
  * Open a dynamically generated app window from an IDL descriptor.
- * Can be called from openApplication() or from the IDL Explorer.
+ * Requires a governed invoker for UIR-035 compliance.
  */
 export function openORBGeneratedApp(
   descriptor: IDLDescriptor,
   createWindowFn: (id: string, title: string, w: number, h: number) => HTMLElement,
-  backendUrl: string = 'http://localhost:8080',
-): void {
-  const displayName = descriptor.ui?.display_name || descriptor.name;
-  const icon = descriptor.ui?.icon || '🔧';
-  const appId = `orb-${descriptor.name}`;
+  backendUrlOrOptions: string | ORBDynamicAppRendererOptions = 'http://localhost:8080',
+): ORBDynamicAppRenderer {
+  const displayName = sanitizeDescriptorText(
+    descriptor.ui?.display_name || descriptor.name,
+    'app',
+  );
+  const icon = sanitizeDescriptorText(descriptor.ui?.icon || '🔧', '🔧');
+  const appId = `orb-${safeIdToken(descriptor.name)}`;
 
   const windowEl = createWindowFn(appId, `${icon} ${displayName} [Auto-UI]`, 800, 600);
   const content = windowEl.querySelector('.window-content') as HTMLElement;
 
-  const renderer = new ORBDynamicAppRenderer(backendUrl);
+  const renderer = new ORBDynamicAppRenderer(backendUrlOrOptions);
   content.innerHTML = renderer.renderApp(descriptor);
   renderer.bindEvents(content, descriptor);
+  return renderer;
 }
 
-// Export for browser global access
 if (typeof window !== 'undefined') {
   (window as any).ORBDynamicAppRenderer = ORBDynamicAppRenderer;
   (window as any).openORBGeneratedApp = openORBGeneratedApp;
+  (window as any).escapeHtml = escapeHtml;
 }
 
 export default ORBDynamicAppRenderer;


### PR DESCRIPTION
Regenerate dashboard tools manifest from current ipfs_kit_py MCP++ server registry for monorepo dashboard parity.