### PR TITLE
fix(ci): Node >=22.19.0 matrix + release-readiness ownership exports

### DIFF
--- a/.github/workflows/ci-robust.yml
+++ b/.github/workflows/ci-robust.yml
@@ -14,7 +14,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: ['20.19.0', '22.12.0']
+        node-version: ['22.19.0', '22.23.1']
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20.19.0', '22.12.0']
+        node-version: ['22.19.0', '22.23.1']
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -124,7 +124,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            NODE_VERSION=20.19.0
+            NODE_VERSION=22.19.0
             BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VCS_REF=${{ github.sha }}
 

--- a/.github/workflows/multi-arch-build.yml
+++ b/.github/workflows/multi-arch-build.yml
@@ -28,31 +28,31 @@ jobs:
           # x86_64 builds
           - os: ubuntu-latest
             arch: x86_64
-            node-version: '20.19.0'
+            node-version: '22.19.0'
             platform: linux/amd64
           - os: ubuntu-latest
             arch: x86_64
-            node-version: '22.12.0'
+            node-version: '22.23.1'
             platform: linux/amd64
           # ARM64 builds (experimental - emulation has limitations)
           - os: ubuntu-latest
             arch: arm64
-            node-version: '20.19.0'
+            node-version: '22.19.0'
             platform: linux/arm64
             experimental: true
           - os: ubuntu-latest
             arch: arm64
-            node-version: '22.12.0'
+            node-version: '22.23.1'
             platform: linux/arm64
             experimental: true
           # macOS builds (x86_64 and ARM64)
           - os: macos-13
             arch: x86_64
-            node-version: '20.19.0'
+            node-version: '22.19.0'
             platform: darwin/amd64
           - os: macos-14
             arch: arm64
-            node-version: '20.19.0'
+            node-version: '22.19.0'
             platform: darwin/arm64
 
     steps:
@@ -170,7 +170,7 @@ jobs:
           echo "✅ CLI tests passed on ${{ matrix.platform }}"
 
       - name: Run unit tests (safe subset)
-        if: matrix.node-version == '20.19.0' && steps.setup-node.outcome == 'success' && steps.build.outcome == 'success'
+        if: matrix.node-version == '22.19.0' && steps.setup-node.outcome == 'success' && steps.build.outcome == 'success'
         run: |
           echo "Running tests on ${{ matrix.platform }}..."
           npm run test:working 2>&1 | tee test-output.log || echo "⚠️ Some tests failed (non-blocking)"
@@ -274,7 +274,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            NODE_VERSION=20.19.0
+            NODE_VERSION=22.19.0
 
       - name: Docker build summary
         run: |
@@ -319,29 +319,29 @@ jobs:
           mkdir -p release-packages
           
           # Package x86_64 builds
-          if [ -d "artifacts/build-ubuntu-latest-x86_64-node20.19.0" ]; then
-            cd artifacts/build-ubuntu-latest-x86_64-node20.19.0
+          if [ -d "artifacts/build-ubuntu-latest-x86_64-node22.19.0" ]; then
+            cd artifacts/build-ubuntu-latest-x86_64-node22.19.0
             tar -czf ../../release-packages/swissknife-linux-x86_64.tar.gz cli.mjs dist/ 2>/dev/null || true
             cd ../..
           fi
           
           # Package ARM64 builds
-          if [ -d "artifacts/build-ubuntu-latest-arm64-node20.19.0" ]; then
-            cd artifacts/build-ubuntu-latest-arm64-node20.19.0
+          if [ -d "artifacts/build-ubuntu-latest-arm64-node22.19.0" ]; then
+            cd artifacts/build-ubuntu-latest-arm64-node22.19.0
             tar -czf ../../release-packages/swissknife-linux-arm64.tar.gz cli.mjs dist/ 2>/dev/null || true
             cd ../..
           fi
           
           # Package macOS x86_64 builds
-          if [ -d "artifacts/build-macos-13-x86_64-node20.19.0" ]; then
-            cd artifacts/build-macos-13-x86_64-node20.19.0
+          if [ -d "artifacts/build-macos-13-x86_64-node22.19.0" ]; then
+            cd artifacts/build-macos-13-x86_64-node22.19.0
             tar -czf ../../release-packages/swissknife-macos-x86_64.tar.gz cli.mjs dist/ 2>/dev/null || true
             cd ../..
           fi
           
           # Package macOS ARM64 builds
-          if [ -d "artifacts/build-macos-14-arm64-node20.19.0" ]; then
-            cd artifacts/build-macos-14-arm64-node20.19.0
+          if [ -d "artifacts/build-macos-14-arm64-node22.19.0" ]; then
+            cd artifacts/build-macos-14-arm64-node22.19.0
             tar -czf ../../release-packages/swissknife-macos-arm64.tar.gz cli.mjs dist/ 2>/dev/null || true
             cd ../..
           fi
@@ -400,8 +400,8 @@ jobs:
           echo "- ✅ macOS ARM64 (Apple Silicon)" >> final-summary.md
           echo "" >> final-summary.md
           echo "## Node.js Versions Tested" >> final-summary.md
-          echo "- Node.js 20.19.0" >> final-summary.md
-          echo "- Node.js 22.12.0" >> final-summary.md
+          echo "- Node.js 22.19.0" >> final-summary.md
+          echo "- Node.js 22.23.1" >> final-summary.md
           
           cat final-summary.md
 

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['20.19.0', '22.12.0']
+        node-version: ['22.19.0', '22.23.1']
     
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: ['20.19.0', '22.12.0']
+        node-version: ['22.19.0', '22.23.1']
     
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/wasm-prover-gates.yml
+++ b/.github/workflows/wasm-prover-gates.yml
@@ -48,10 +48,10 @@ jobs:
         with:
           submodules: false
 
-      - name: Set up Node.js 22.12.0
+      - name: Set up Node.js 22.23.1
         uses: actions/setup-node@v4
         with:
-          node-version: '22.12.0'
+          node-version: '22.23.1'
           cache: 'npm'
 
       - name: Verify browser-validation toolchain

--- a/scripts/lib/release-readiness-evidence-producers.mjs
+++ b/scripts/lib/release-readiness-evidence-producers.mjs
@@ -126,6 +126,199 @@ export const RELEASE_EVIDENCE_PRODUCER_GATES = [
 export const INDEPENDENT_REPLAY_EVIDENCE_FILE = 'independent-all-app-release-replay.json';
 
 /**
+ * SWR-160 / release-readiness surface ownership: every executable entrypoint
+ * that participates in the release-readiness producer boundary must appear
+ * here exactly once. `scripts/audit-source-modules.mjs` and
+ * `docs/release-readiness-ownership.md` treat this export as the source of
+ * truth for ownership classification.
+ */
+// Plain array literal required: scripts/audit-source-modules.mjs parses this
+// export statically via `export const NAME = [ ... ]` (no Object.freeze wrap).
+export const RELEASE_READINESS_ENTRYPOINT_OWNERSHIP = [
+  {
+    path: 'scripts/lib/release-readiness-evidence-producers.mjs',
+    owner: 'release-readiness',
+    runtime: 'host-release',
+    auditDecision: 'Authoritative producer manifest for ownership, dependencies, artifact paths, default enablement, and evidence verification. No second executable producer list is permitted.',
+  },
+  {
+    path: 'scripts/release-readiness-gate.mjs',
+    owner: 'release-readiness',
+    runtime: 'host-release',
+    auditDecision: 'Production gate imports the manifest, cold-resets only manifest-owned artifacts, enforces dependencies, runs each default-enabled producer, and reports missing or invalid producer evidence.',
+  },
+  {
+    path: 'scripts/lib/release-reproduction-attestation.mjs',
+    owner: 'release-readiness',
+    runtime: 'host-release',
+    auditDecision: 'SWR-141 provenance helper that captures clean-checkout reproduction, source/evidence fingerprints, tool versions, and GO/NO_GO blockers.',
+  },
+  {
+    path: 'scripts/capture-refactor-main-reconciliation.cjs',
+    owner: 'release-readiness',
+    runtime: 'host-release',
+    auditDecision: 'SWR-162 merge receipt producer. Records accepted integration ranges and preserves rejected stale refs without merging them wholesale.',
+  },
+  {
+    path: 'scripts/lib/pick-free-port.mjs',
+    owner: 'release-readiness',
+    runtime: 'host-release',
+    auditDecision: 'Endpoint lease helper. Proves this process can bind a candidate port and returns explicit lease ownership metadata; never reuses or kills a foreign listener.',
+  },
+  {
+    path: 'scripts/run-with-owned-port.mjs',
+    owner: 'release-readiness',
+    runtime: 'host-release',
+    auditDecision: 'Wrapper exports the leased port to one child command. If the preferred port is occupied, the foreign listener is left untouched and a private verified-free port is used.',
+  },
+  {
+    path: 'build-tools/configs/playwright.live-behavior-proof.config.ts',
+    owner: 'release-readiness',
+    runtime: 'browser-playwright',
+    auditDecision: 'Dedicated current-behavior proof config. The spec owns its in-process fixture on an ephemeral port and writes real browser evidence and screenshots.',
+  },
+  {
+    path: 'build-tools/configs/playwright.live-gateway.config.ts',
+    owner: 'release-readiness',
+    runtime: 'browser-playwright',
+    auditDecision: 'Dedicated application-originated gateway config. Uses reuseExistingServer: false, a strict leased port, and never attaches to an existing foreign dev server.',
+  },
+  {
+    path: 'test/architecture/release-readiness-hermetic.test.ts',
+    owner: 'release-readiness',
+    runtime: 'host-release',
+    auditDecision: 'Hermetic regression coverage imports the production manifest and owned-port helper instead of a task-local producer list.',
+  },
+];
+
+/**
+ * Validate producer + ownership manifests for internal consistency.
+ * Returns an array of human-readable violation strings (empty when valid).
+ */
+export function validateReleaseReadinessManifest({
+  producers = RELEASE_EVIDENCE_PRODUCER_GATES,
+  ownership = RELEASE_READINESS_ENTRYPOINT_OWNERSHIP,
+  requiredEntrypoints = RELEASE_READINESS_ENTRYPOINT_OWNERSHIP.map((entry) => entry.path),
+} = {}) {
+  const violations = [];
+  const ownershipPaths = new Set();
+
+  for (const entry of ownership) {
+    if (!entry?.path) {
+      violations.push('ownership record is missing path');
+      continue;
+    }
+    if (ownershipPaths.has(entry.path)) {
+      violations.push(`duplicate ownership path: ${entry.path}`);
+    }
+    ownershipPaths.add(entry.path);
+    if (entry.owner !== 'release-readiness') {
+      violations.push(`ownership owner for ${entry.path} must be release-readiness`);
+    }
+    if (!entry.runtime || typeof entry.runtime !== 'string') {
+      violations.push(`ownership runtime missing for ${entry.path}`);
+    }
+    if (!entry.auditDecision || !String(entry.auditDecision).trim()) {
+      violations.push(`ownership auditDecision missing for ${entry.path}`);
+    }
+  }
+
+  for (const required of requiredEntrypoints) {
+    if (!ownershipPaths.has(required)) {
+      violations.push(`required entrypoint missing from ownership export: ${required}`);
+    }
+  }
+
+  const ids = new Set();
+  const claimedFiles = new Map();
+  for (const producer of producers) {
+    if (!producer?.id) {
+      violations.push('producer is missing id');
+      continue;
+    }
+    if (ids.has(producer.id)) {
+      violations.push(`duplicate producer id: ${producer.id}`);
+    }
+    ids.add(producer.id);
+
+    for (const file of producer.evidenceFiles ?? []) {
+      if (claimedFiles.has(file)) {
+        violations.push(
+          `duplicate evidence file ownership: ${file} claimed by ${claimedFiles.get(file)} and ${producer.id}`,
+        );
+      } else {
+        claimedFiles.set(file, producer.id);
+      }
+    }
+
+    for (const dep of producer.dependsOn ?? []) {
+      if (!ids.has(dep) && !producers.some((item) => item.id === dep)) {
+        // Dependency may appear later in the list; final pass below.
+      }
+    }
+  }
+
+  for (const producer of producers) {
+    for (const dep of producer.dependsOn ?? []) {
+      if (!ids.has(dep)) {
+        violations.push(`producer ${producer.id} depends on unknown producer ${dep}`);
+        continue;
+      }
+      const producerIndex = producers.findIndex((item) => item.id === producer.id);
+      const depIndex = producers.findIndex((item) => item.id === dep);
+      if (depIndex > producerIndex) {
+        violations.push(
+          `producer ${producer.id} depends on ${dep} which is declared later in the manifest order`,
+        );
+      }
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Expand the producer manifest into gate entries for `release-readiness-gate.mjs`.
+ * This is the only supported release-gate producer expansion boundary.
+ *
+ * `runProducer(producer)` must return `{ ok, status, durationMs, tail }` the
+ * same shape `runSingleProducerGate` expects.
+ */
+export function createReleaseEvidenceProducerGateEntries({
+  runProducer,
+  producers = RELEASE_EVIDENCE_PRODUCER_GATES,
+  evidenceRoot: evidenceRootDir = evidenceRoot,
+  repoRoot: repoRootDir = repoRoot,
+} = {}) {
+  if (typeof runProducer !== 'function') {
+    throw new Error('createReleaseEvidenceProducerGateEntries requires runProducer(producer)');
+  }
+
+  return producers.map((producer) => ({
+    id: producer.id,
+    label: producer.label,
+    defaultEnabled: producer.defaultEnabled !== false,
+    run: () =>
+      runSingleProducerGate(producer, {
+        runProducer: () => runProducer(producer),
+        evidenceRoot: evidenceRootDir,
+        repoRoot: repoRootDir,
+      }),
+  }));
+}
+
+/**
+ * Absolute paths for every evidence artifact the release-readiness surface owns
+ * (producer evidence + independent replay receipt).
+ */
+export function releaseReadinessEvidenceAbsolutePaths(
+  producers = RELEASE_EVIDENCE_PRODUCER_GATES,
+  evidenceRootDir = evidenceRoot,
+) {
+  return producerEvidenceAbsolutePaths(producers, evidenceRootDir);
+}
+
+/**
  * Absolute paths to every evidence file `producers` owns, resolved against
  * `evidenceRootDir`. Both arguments default to the real production manifest
  * and evidence root so existing callers do not need to change, but the

--- a/scripts/release-readiness-gate.mjs
+++ b/scripts/release-readiness-gate.mjs
@@ -51,8 +51,9 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import {
   RELEASE_EVIDENCE_PRODUCER_GATES,
+  createReleaseEvidenceProducerGateEntries,
   resetReleaseEvidenceProducers,
-  runSingleProducerGate,
+  validateReleaseReadinessManifest,
 } from './lib/release-readiness-evidence-producers.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -1701,18 +1702,52 @@ function main() {
     // every time -- so `npm run release:readiness` from a clean checkout
     // regenerates them itself instead of aggregating whatever gitignored
     // receipts happen to already exist in the working tree (see the
-    // cold-start reset above `main()`'s gate loop).
-    ...RELEASE_EVIDENCE_PRODUCER_GATES.map((producer) => ({
-      id: producer.id,
-      label: producer.label,
+    // cold-start reset above `main()`'s gate loop). Expansion goes through
+    // createReleaseEvidenceProducerGateEntries only (SWR-160 public API).
+    {
+      id: 'release-producer-manifest-preflight',
+      label: 'Release producer manifest ownership preflight (SWR-160)',
       run: () => {
-        const outcome = runSingleProducerGate(producer, { runProducer: () => runNpmScript(producer.npmScript) });
+        const violations = validateReleaseReadinessManifest();
+        if (violations.length === 0) {
+          return { ok: true, status: 0, durationMs: 0, tail: [], findings: [] };
+        }
+        const findings = [];
+        for (const violation of violations) {
+          pushFinding(findings, 'release-producer-manifest-preflight', violation, 'scripts/lib/release-readiness-evidence-producers.mjs');
+        }
+        return {
+          ok: false,
+          status: 1,
+          durationMs: 0,
+          tail: violations,
+          findings,
+        };
+      },
+    },
+    ...createReleaseEvidenceProducerGateEntries({
+      runProducer: (producer) => runNpmScript(producer.npmScript),
+    }).map((entry) => ({
+      id: entry.id,
+      label: entry.label,
+      run: () => {
+        const outcome = entry.run();
         const findings = [];
         for (const file of outcome.missingFiles ?? []) {
-          pushFinding(findings, `${producer.id}-missing-evidence-file`, `${producer.label} did not produce required evidence`, file);
+          pushFinding(
+            findings,
+            `${entry.id}-missing-evidence-file`,
+            `${entry.label} did not produce required evidence`,
+            file,
+          );
         }
         for (const dir of outcome.missingDirs ?? []) {
-          pushFinding(findings, `${producer.id}-missing-evidence-dir`, `${producer.label} did not produce required (non-empty) evidence directory`, dir);
+          pushFinding(
+            findings,
+            `${entry.id}-missing-evidence-dir`,
+            `${entry.label} did not produce required (non-empty) evidence directory`,
+            dir,
+          );
         }
         return { ...outcome, findings };
       },


### PR DESCRIPTION
## Summary
Unblocks SwissKnife main CI red state that predated DCR test landings.

1. **Node policy alignment** — CI matrices still used `20.19.0` / `22.12.0` while `package.json` engines and `scripts/verify-browser-toolchain.mjs` require `>=22.19.0`. Bumped primary matrices to `22.19.0` + `22.23.1` (`.nvmrc`), including multi-arch / docker / wasm / production-deployment workflows.

2. **SWR-160 release-readiness ownership surface** — docs already described `RELEASE_READINESS_ENTRYPOINT_OWNERSHIP` and public API exports, but the producer manifest never declared them, so `npm run lint` / Code Validation failed with 17 release-readiness surface violations.

Adds:
- `RELEASE_READINESS_ENTRYPOINT_OWNERSHIP` (plain array for static audit parse)
- `validateReleaseReadinessManifest()`
- `createReleaseEvidenceProducerGateEntries()` (gate expansion boundary)
- `releaseReadinessEvidenceAbsolutePaths()`
- gate preflight + producer expansion via the new public API

## Local verification
- `node scripts/audit-source-modules.mjs --fail-on-unknown --fail-on-forbidden` → **0** release-readiness surface violations (was 17)

## Test plan
- [ ] Code Validation job green
- [ ] Core Tests on Node 22.19.0 / 22.23.1 pass toolchain verify
- [ ] No remaining workflow pins of 20.19.0 / 22.12.0